### PR TITLE
Add `TOMLArrayIterator` and `TOMLTableIterator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1](https://github.com/LebJe/TOMLKit/releases/tag/0.1.0) - 2021-06-17
+
+### Added
+
+-   Add `TOMLArrayIterator` and `TOMLTableIterator`.
+
+### Fixed
+
+-   `TOMLArray.checkIndex(index:)` now checks that `index <= self.endIndex - 1` instead of `index <= self.endIndex`.
+
 ## [0.1.0](https://github.com/LebJe/TOMLKit/releases/tag/0.1.0) - 2021-06-17
 
 ### Added

--- a/Sources/TOMLKit/TOML Data Types/TOMLArray/TOMLArray+CollectionConformance.swift
+++ b/Sources/TOMLKit/TOML Data Types/TOMLArray/TOMLArray+CollectionConformance.swift
@@ -19,7 +19,7 @@ extension TOMLArray:
 	public var indices: Range<Index> { 0..<self.endIndex }
 
 	private func checkIndex(_ index: Index) {
-		precondition(index <= self.endIndex, "TOMLArray index out of bounds")
+		precondition(index <= self.endIndex - 1, "TOMLArray index out of bounds")
 	}
 
 	private func isEmptyPrecondition() {

--- a/Sources/TOMLKit/TOML Data Types/TOMLArray/TOMLArray.swift
+++ b/Sources/TOMLKit/TOML Data Types/TOMLArray/TOMLArray.swift
@@ -9,6 +9,7 @@ import CTOML
 /// An array in a TOML document.
 public class TOMLArray:
 	Equatable,
+	Sequence,
 	ExpressibleByArrayLiteral,
 	CustomDebugStringConvertible,
 	TOMLValueConvertible
@@ -79,5 +80,9 @@ public class TOMLArray:
 
 	public static func == (lhs: TOMLArray, rhs: TOMLArray) -> Bool {
 		arrayEqual(lhs.arrayPointer, rhs.arrayPointer)
+	}
+
+	public func makeIterator() -> TOMLArrayIterator {
+		TOMLArrayIterator(array: self)
 	}
 }

--- a/Sources/TOMLKit/TOML Data Types/TOMLArray/TOMLArrayIterator.swift
+++ b/Sources/TOMLKit/TOML Data Types/TOMLArray/TOMLArrayIterator.swift
@@ -1,9 +1,8 @@
+// Copyright (c) 2021 Jeff Lebrun
 //
-//  File.swift
-//  
+//  Licensed under the MIT License.
 //
-//  Created by Jeff Lebrun on 6/22/21.
-//
+//  The full text of the license can be found in the file named LICENSE.
 
 public struct TOMLArrayIterator: IteratorProtocol {
 	let array: TOMLArray
@@ -11,8 +10,8 @@ public struct TOMLArrayIterator: IteratorProtocol {
 
 	public mutating func next() -> TOMLValueConvertible? {
 		guard self.currentIndex <= self.array.endIndex - 1 else { return nil }
-		let element = array[self.currentIndex]
-		currentIndex += 1
+		let element = self.array[self.currentIndex]
+		self.currentIndex += 1
 		return element
 	}
 }

--- a/Sources/TOMLKit/TOML Data Types/TOMLArray/TOMLArrayIterator.swift
+++ b/Sources/TOMLKit/TOML Data Types/TOMLArray/TOMLArrayIterator.swift
@@ -1,0 +1,18 @@
+//
+//  File.swift
+//  
+//
+//  Created by Jeff Lebrun on 6/22/21.
+//
+
+public struct TOMLArrayIterator: IteratorProtocol {
+	let array: TOMLArray
+	var currentIndex = 0
+
+	public mutating func next() -> TOMLValueConvertible? {
+		guard self.currentIndex <= self.array.endIndex - 1 else { return nil }
+		let element = array[self.currentIndex]
+		currentIndex += 1
+		return element
+	}
+}

--- a/Sources/TOMLKit/TOML Data Types/TOMLTable/TOMLTable+CollectionFunctions.swift
+++ b/Sources/TOMLKit/TOML Data Types/TOMLTable/TOMLTable+CollectionFunctions.swift
@@ -37,20 +37,7 @@ public extension TOMLTable {
 		}
 	}
 
-	func next() -> (String, TOMLValueConvertible)? {
-		if self.currentIndex == 0 {
-			self.storedKeys = self.keys
-		}
-
-		guard self.currentIndex <= self.count - 1 else {
-			self.currentIndex = 0
-			self.storedKeys = []
-			return nil
-		}
-
-		let v = (self.storedKeys[self.currentIndex], self[self.storedKeys[self.currentIndex]]!)
-		self.currentIndex += 1
-
-		return v
+	func makeIterator() -> TOMLTableIterator {
+		TOMLTableIterator(table: self)
 	}
 }

--- a/Sources/TOMLKit/TOML Data Types/TOMLTable/TOMLTable.swift
+++ b/Sources/TOMLKit/TOML Data Types/TOMLTable/TOMLTable.swift
@@ -23,11 +23,9 @@ public class TOMLTable:
 	ExpressibleByDictionaryLiteral,
 	CustomDebugStringConvertible,
 	TOMLValueConvertible,
-	Sequence,
-	IteratorProtocol
+	Sequence
 {
-	var currentIndex = 0
-	var storedKeys: [String] = []
+
 	public var type: TOMLType { .table }
 	public var debugDescription: String { self.convert() }
 	public var tomlValue: TOMLValue { get { .init(self) } set {} }

--- a/Sources/TOMLKit/TOML Data Types/TOMLTable/TOMLTable.swift
+++ b/Sources/TOMLKit/TOML Data Types/TOMLTable/TOMLTable.swift
@@ -25,7 +25,6 @@ public class TOMLTable:
 	TOMLValueConvertible,
 	Sequence
 {
-
 	public var type: TOMLType { .table }
 	public var debugDescription: String { self.convert() }
 	public var tomlValue: TOMLValue { get { .init(self) } set {} }

--- a/Sources/TOMLKit/TOML Data Types/TOMLTable/TOMLTableIterator.swift
+++ b/Sources/TOMLKit/TOML Data Types/TOMLTable/TOMLTableIterator.swift
@@ -1,0 +1,34 @@
+//
+//  File.swift
+//  
+//
+//  Created by Jeff Lebrun on 6/22/21.
+//
+
+
+public struct TOMLTableIterator: IteratorProtocol {
+	let table: TOMLTable
+	var currentIndex = 0
+	var storedKeys: [String] = []
+
+	init(table: TOMLTable) {
+		self.table = table
+	}
+
+	public mutating func next() -> (String, TOMLValueConvertible)? {
+		if self.currentIndex == 0 {
+			self.storedKeys = self.table.keys
+		}
+
+		guard self.currentIndex <= self.table.count - 1 else {
+			self.currentIndex = 0
+			self.storedKeys = []
+			return nil
+		}
+
+		let v = (self.storedKeys[self.currentIndex], self.table[self.storedKeys[self.currentIndex]]!)
+		self.currentIndex += 1
+
+		return v
+	}
+}

--- a/Sources/TOMLKit/TOML Data Types/TOMLTable/TOMLTableIterator.swift
+++ b/Sources/TOMLKit/TOML Data Types/TOMLTable/TOMLTableIterator.swift
@@ -1,10 +1,8 @@
+// Copyright (c) 2021 Jeff Lebrun
 //
-//  File.swift
-//  
+//  Licensed under the MIT License.
 //
-//  Created by Jeff Lebrun on 6/22/21.
-//
-
+//  The full text of the license can be found in the file named LICENSE.
 
 public struct TOMLTableIterator: IteratorProtocol {
 	let table: TOMLTable


### PR DESCRIPTION
## Added

-   Add `TOMLArrayIterator` and `TOMLTableIterator`.

## Fixed

-   `TOMLArray.checkIndex(index:)` now checks that `index <= self.endIndex - 1` instead of `index <= self.endIndex`.