### PR TITLE
Make `TOMLEncoder.dataEncoder` More Generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0](https://github.com/LebJe/TOMLKit/releases/tag/0.2.0) - 2021-09-01
+
+### Added
+
+-   `TOMLEncoder.dataEncoder` now allows one to encode `Data` into any type that conforms to `TOMLValueConvertible`.
+
+### Fixed
+
+-	`TOMLDecoder` now passes `TOMLDecoder.userInfo` to `InternalTOMLDecoder`'s initializer.
+-	Improved code formatting.
+
 ## [0.1.2](https://github.com/LebJe/TOMLKit/releases/tag/0.1.2) - 2021-07-27
 
 ### Added

--- a/Sources/TOMLKit/Decoder/InternalTOMLDecoder.swift
+++ b/Sources/TOMLKit/Decoder/InternalTOMLDecoder.swift
@@ -19,12 +19,22 @@ final class InternalTOMLDecoder: Decoder {
 	}
 
 	func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key: CodingKey {
-		KeyedDecodingContainer<Key>(KDC(tomlValue: self.tomlValue, codingPath: self.codingPath, userInfo: self.userInfo, dataDecoder: self.dataDecoder))
+		KeyedDecodingContainer<Key>(
+            KDC(
+                tomlValue: self.tomlValue,
+                codingPath: self.codingPath,
+                userInfo: self.userInfo,
+                dataDecoder: self.dataDecoder
+            )
+        )
 	}
 
 	func unkeyedContainer() throws -> UnkeyedDecodingContainer {
 		guard let array = self.tomlValue.array else {
-			throw DecodingError.typeMismatch(TOMLArray.self, DecodingError.Context(codingPath: self.codingPath, debugDescription: "Expected a TOMLArray but found a \(self.tomlValue.type) instead."))
+			throw DecodingError.typeMismatch(
+                TOMLArray.self,
+                DecodingError.Context(codingPath: self.codingPath, debugDescription: "Expected a TOMLArray but found a \(self.tomlValue.type) instead.")
+            )
 		}
 		return UDC(array, codingPath: self.codingPath, userInfo: self.userInfo, dataDecoder: self.dataDecoder)
 	}

--- a/Sources/TOMLKit/Decoder/TOMLDecoder.swift
+++ b/Sources/TOMLKit/Decoder/TOMLDecoder.swift
@@ -27,7 +27,7 @@ public struct TOMLDecoder {
 	/// - Returns: The decoded type.
 	public func decode<T: Decodable>(_ type: T.Type, from tomlString: String) throws -> T {
 		let table = try TOMLTable(string: tomlString)
-		let decoder = InternalTOMLDecoder(table.tomlValue, dataDecoder: self.dataDecoder)
+		let decoder = InternalTOMLDecoder(table.tomlValue, userInfo: self.userInfo, dataDecoder: self.dataDecoder)
 		return try T(from: decoder)
 	}
 
@@ -38,7 +38,7 @@ public struct TOMLDecoder {
 	/// - Throws: `DecodingError`.
 	/// - Returns: The decoded type.
 	public func decode<T: Decodable>(_ type: T.Type, from table: TOMLTable) throws -> T {
-		let decoder = InternalTOMLDecoder(table.tomlValue, dataDecoder: self.dataDecoder)
+		let decoder = InternalTOMLDecoder(table.tomlValue, userInfo: self.userInfo, dataDecoder: self.dataDecoder)
 		return try T(from: decoder)
 	}
 }

--- a/Sources/TOMLKit/Decoder/UnkeyedDecodingContainer.swift
+++ b/Sources/TOMLKit/Decoder/UnkeyedDecodingContainer.swift
@@ -122,7 +122,14 @@ extension InternalTOMLDecoder.UDC {
 	}
 
 	mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey {
-		KeyedDecodingContainer<NestedKey>(InternalTOMLDecoder.KDC(tomlValue: self.tomlArray.tomlValue, codingPath: self.codingPath, userInfo: self.userInfo, dataDecoder: self.dataDecoder))
+		KeyedDecodingContainer<NestedKey>(
+            InternalTOMLDecoder.KDC(
+                tomlValue: self.tomlArray.tomlValue,
+                codingPath: self.codingPath,
+                userInfo: self.userInfo,
+                dataDecoder: self.dataDecoder
+            )
+        )
 	}
 
 	mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {

--- a/Sources/TOMLKit/Encoder/InternalTOMLEncoder.swift
+++ b/Sources/TOMLKit/Encoder/InternalTOMLEncoder.swift
@@ -16,14 +16,14 @@ final class InternalTOMLEncoder: Encoder {
 	var userInfo: [CodingUserInfoKey: Any]
 	let tomlValueOrArray: Either<TOMLValue, (array: TOMLArray, index: Int)>
 	let parentKey: CodingKey?
-	let dataEncoder: (Data) -> String
+	let dataEncoder: (Data) -> TOMLValueConvertible
 
 	init(
 		_ tomlValueOrArray: Either<TOMLValue, (array: TOMLArray, index: Int)>,
 		parentKey: CodingKey? = nil,
 		codingPath: [CodingKey],
 		userInfo: [CodingUserInfoKey: Any],
-		dataEncoder: @escaping (Data) -> String
+		dataEncoder: @escaping (Data) -> TOMLValueConvertible
 	) {
 		self.tomlValueOrArray = tomlValueOrArray
 		self.parentKey = parentKey
@@ -113,13 +113,13 @@ final class InternalTOMLEncoder: Encoder {
 		var userInfo: [CodingUserInfoKey: Any]
 		let tomlValueOrArray: Either<TOMLValue, (array: TOMLArray, index: Int)>
 		let parentKey: CodingKey?
-		let dataEncoder: (Data) -> String
+		let dataEncoder: (Data) -> TOMLValueConvertible
 
 		init(
 			_ tomlValueOrArray: Either<TOMLValue, (array: TOMLArray, index: Int)>,
 			parentKey: CodingKey?,
 			userInfo: [CodingUserInfoKey: Any] = [:],
-			dataEncoder: @escaping (Data) -> String
+			dataEncoder: @escaping (Data) -> TOMLValueConvertible
 		) {
 			self.tomlValueOrArray = tomlValueOrArray
 			self.parentKey = parentKey
@@ -134,14 +134,14 @@ final class InternalTOMLEncoder: Encoder {
 		var userInfo: [CodingUserInfoKey: Any]
 		let tomlValue: TOMLValue
 		let parentKey: CodingKey?
-		let dataEncoder: (Data) -> String
+		let dataEncoder: (Data) -> TOMLValueConvertible
 
 		init(
 			_ tomlValue: TOMLValue,
 			parentKey: CodingKey? = nil,
 			codingPath: [CodingKey],
 			userInfo: [CodingUserInfoKey: Any] = [:],
-			dataEncoder: @escaping (Data) -> String
+			dataEncoder: @escaping (Data) -> TOMLValueConvertible
 		) {
 			self.tomlValue = tomlValue
 			self.parentKey = parentKey
@@ -154,7 +154,7 @@ final class InternalTOMLEncoder: Encoder {
 	struct UEC: UnkeyedEncodingContainer {
 		var codingPath: [CodingKey]
 		var userInfo: [CodingUserInfoKey: Any] = [:]
-		let dataEncoder: (Data) -> String
+		let dataEncoder: (Data) -> TOMLValueConvertible
 		var currentIndex: Int = 0
 		let tomlArray: TOMLArray
 
@@ -166,7 +166,7 @@ final class InternalTOMLEncoder: Encoder {
 			_ tomlArray: TOMLArray,
 			codingPath: [CodingKey],
 			userInfo: [CodingUserInfoKey: Any],
-			dataEncoder: @escaping (Data) -> String
+			dataEncoder: @escaping (Data) -> TOMLValueConvertible
 		) {
 			self.tomlArray = tomlArray
 			self.codingPath = codingPath

--- a/Sources/TOMLKit/TOML Data Types/TOMLValueConvertible.swift
+++ b/Sources/TOMLKit/TOML Data Types/TOMLValueConvertible.swift
@@ -17,6 +17,7 @@
 import CTOML
 import struct Foundation.Data
 
+/// A type that can be converted into a value in a TOML document.
 public protocol TOMLValueConvertible: CustomDebugStringConvertible {
 	/// What kind of TOML value this is.
 	var type: TOMLType { get }


### PR DESCRIPTION
### Added

-   `TOMLEncoder.dataEncoder` now allows one to encode `Data` into any type that conforms to `TOMLValueConvertible`.

### Fixed

-	`TOMLDecoder` now passes `TOMLDecoder.userInfo` to `InternalTOMLDecoder`'s initializer.
-	Improved code formatting.
