### PR TITLE
Changes and Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0](https://github.com/LebJe/TOMLKit/releases/tag/0.3.0) - 2021-09-06
+
+### Added
+
+-   Links to the official documentation from `TOMLInt`, `TOMLTable`, `TOMLArray`, `TOMLDate`, `TOMLTime`, `TOMLDateTime`, and `TOMLTimeOffset`.
+-   [toml++](https://github.com/marzer/tomlplusplus/) is now used to format `TOMLArray`, `TOMLDate`, `TOMLTime`, and `TOMLDateTime`, when they are being printed.
+-   Improved the formatting of strings in `TOMLValue.debugDescription`.
+-   Setting a value in a `TOMLTable` or `TOMLArray` via a nested subscript is now possible.
+
+```swift
+tomlTable["InnerTable"]?["Int"] = 1
+tomlArray[0]?[0] = "Hello, World!"
+```
+
+### Changed
+
+-   Improved the debug output of `TOMLParseError`.
+
+### Fixed
+
+-   It is no longer necessary to add `.tomlValue` after the first subscript in a subscript chain.
+
+```swift
+// Before:
+tomlTable["InnerTable"]?.tomlValue["InnerTable"]
+tomlArray[0]?.tomlValue[0]
+
+// After:
+tomlTable["InnerTable"]?["InnerTable"]
+tomlArray[0]?[0]
+```
+
 ## [0.2.0](https://github.com/LebJe/TOMLKit/releases/tag/0.2.0) - 2021-09-01
 
 ### Added

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,11 @@ let package = Package(
 	products: [
 		.library(name: "TOMLKit", targets: ["TOMLKit"]),
 	],
-	dependencies: [],
+	dependencies: [
+		// Use this dependency when one of the `TOMLTable` comparison tests fail and
+		// XCTAssertEqual tells you "<huge TOMLTable> is not equal to <other huge TOMLTable>"
+		// .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.1.0")
+	],
 	targets: [
 		.target(
 			name: "CTOML",
@@ -28,7 +32,7 @@ let package = Package(
 		),
 		.testTarget(
 			name: "TOMLKitTests",
-			dependencies: ["TOMLKit"]
+			dependencies: ["TOMLKit" /* .product(name: "CustomDump", package: "swift-custom-dump") */ ]
 		),
 	],
 	cLanguageStandard: .c99,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TOMLKit
 
-**A small, simple TOML parser for Swift. Powered by toml++.**
+**A small, simple TOML parser for Swift. Powered by [toml++](https://github.com/marzer/tomlplusplus/).**
 
 [![Swift 5.4](https://img.shields.io/badge/Swift-5.4-brightgreen?logo=swift)](https://swift.org)
 [![SPM Compatible](https://img.shields.io/badge/SPM-compatible-brightgreen.svg)](https://swift.org/package-manager)
@@ -9,7 +9,7 @@
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FLebJe%2FTOMLKit%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/LebJe/TOMLKit)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FLebJe%2FTOMLKit%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/LebJe/TOMLKit)
 
-TOMLKit is a [Swift](https://swift.org) wrapper around [toml++](https://github.com/marzer/tomlplusplus/), allowing you to read and write [TOML](https://toml.io/en/) files in Swift.
+TOMLKit is a [Swift](https://swift.org) wrapper around [toml++](https://github.com/marzer/tomlplusplus/), allowing you to read and write [TOML](https://toml.io) files in Swift.
 
 ## Table of Contents
 
@@ -28,6 +28,7 @@ TOMLKit is a [Swift](https://swift.org) wrapper around [toml++](https://github.c
             -   [Arrays](#arrays)
             -   [Dates](#dates)
             -   [Times](#times)
+            -   [Data](#data)
             -   [Integers](#integers)
         -   [Retrieving TOML values](#retrieving-toml-values)
             -   [From Tables](#from-tables)
@@ -38,7 +39,7 @@ TOMLKit is a [Swift](https://swift.org) wrapper around [toml++](https://github.c
     -   [Licenses](#licenses)
     -   [Contributing](#contributing)
 
-<!-- Added by: lebje, at: Tue Jul 27 15:33:29 EDT 2021 -->
+<!-- Added by: lebje, at: Mon Sep  6 14:34:16 EDT 2021 -->
 
 <!--te-->
 
@@ -252,7 +253,7 @@ if let bool = table["bool"]?.bool {
    print(bool)
 }
 
-if let double = table["InnerTable"]?.tomlValue["InnerInnerTable"]?["InnerInnerInnerTable"]?.double {
+if let double = table["InnerTable"]?["InnerInnerTable"]?["InnerInnerInnerTable"]?.double {
 print(double)
 }
 
@@ -272,7 +273,7 @@ if let bool = array[1].bool? {
    print(bool)
 }
 
-if let double = array[2][0].double? {
+if let double = array[2][0]?.double? {
    print(double)
 }
 

--- a/Sources/CTOML/Sources/Array.cpp
+++ b/Sources/CTOML/Sources/Array.cpp
@@ -159,11 +159,16 @@ extern "C" {
 	void arrayReplaceArray(CTOMLArray * array, int64_t index, CTOMLArray * _Nonnull arrayToEmplace) {
 		auto arr = reinterpret_cast<toml::array *>(array);
 
+		// FIXME: If we don't create a new `toml::array`, sometimes accessing `arrToInsert` crashes.
+		// Also, creating a new `toml::array` is inefficient.
+		auto arrToInsert = toml::array(*reinterpret_cast<toml::array *>(arrayToEmplace));
+		//auto arrToInsert = reinterpret_cast<toml::array *>(arrayToEmplace);
+
 		if (arr->get(index)) {
 			arr->erase(arr->cbegin() + index);
 		}
 
-		arr->insert(arr->cbegin() + index, *reinterpret_cast<toml::array *>(arrayToEmplace));
+		arr->insert(arr->cbegin() + index, arrToInsert);
 	}
 
 	/// Replace the \c toml::table at \c index with \c table .
@@ -192,6 +197,16 @@ extern "C" {
 	void arrayRemoveElement(CTOMLArray * array, int64_t index) {
 		auto arr = reinterpret_cast<toml::array *>(array);
 		arr->erase(arr->cbegin() + index);
+	}
+
+	// MARK: - Array Printing
+
+	const char * _Nonnull arrayConvertToTOML(CTOMLArray * _Nonnull array) {
+		std::stringstream ss;
+
+		ss << toml::default_formatter { *reinterpret_cast<toml::array *>(array) };
+
+		return strdup(ss.str().c_str());
 	}
 
 #ifdef __cplusplus

--- a/Sources/CTOML/Sources/Date&Time&DateTime.cpp
+++ b/Sources/CTOML/Sources/Date&Time&DateTime.cpp
@@ -1,0 +1,32 @@
+
+#include <CTOML/CTOML.h>
+#include <string>
+#include "toml.hpp"
+#include "Conversion.hpp"
+
+/// Convert \c date to TOML.
+const char * _Nonnull cTOMLDateToTOML(CTOMLDate date) {
+	std::stringstream ss;
+
+	ss << cTOMLDateToTomlDate(date);
+
+	return strdup(ss.str().c_str());
+}
+
+/// Convert \c time to TOML.
+const char * _Nonnull cTOMLTimeToTOML(CTOMLTime time) {
+	std::stringstream ss;
+
+	ss << cTOMLTimeToTomlTime(time);
+
+	return strdup(ss.str().c_str());
+}
+
+/// Convert \c dateTime to TOML.
+const char * _Nonnull cTOMLDateTimeToTOML(CTOMLDateTime dateTime) {
+	std::stringstream ss;
+
+	ss << cTOMLDateTimeToTomlDateTime(dateTime);
+
+	return strdup(ss.str().c_str());
+}

--- a/Sources/CTOML/Sources/toml.hpp
+++ b/Sources/CTOML/Sources/toml.hpp
@@ -8744,7 +8744,7 @@ TOML_ANON_NAMESPACE_START
 	}
 
 	template <uint64_t> struct parse_integer_traits;
-	template <> struct parse_integer_traits<2> final
+	template <> struct parse_integer_traits<2>
 	{
 		static constexpr auto scope_qualifier = "binary integer"sv;
 		static constexpr auto is_digit = ::toml::impl::is_binary_digit;
@@ -8753,7 +8753,7 @@ TOML_ANON_NAMESPACE_START
 		static constexpr auto prefix_codepoint = U'b';
 		static constexpr auto prefix = "b"sv;
 	};
-	template <> struct parse_integer_traits<8> final
+	template <> struct parse_integer_traits<8>
 	{
 		static constexpr auto scope_qualifier = "octal integer"sv;
 		static constexpr auto is_digit = ::toml::impl::is_octal_digit;
@@ -8762,14 +8762,14 @@ TOML_ANON_NAMESPACE_START
 		static constexpr auto prefix_codepoint = U'o';
 		static constexpr auto prefix = "o"sv;
 	};
-	template <> struct parse_integer_traits<10> final
+	template <> struct parse_integer_traits<10>
 	{
 		static constexpr auto scope_qualifier = "decimal integer"sv;
 		static constexpr auto is_digit = ::toml::impl::is_decimal_digit;
 		static constexpr auto is_signed = true;
 		static constexpr auto buffer_length = 19; //strlen("9223372036854775807")
 	};
-	template <> struct parse_integer_traits<16> final
+	template <> struct parse_integer_traits<16>
 	{
 		static constexpr auto scope_qualifier = "hexadecimal integer"sv;
 		static constexpr auto is_digit = ::toml::impl::is_hexadecimal_digit;
@@ -8891,7 +8891,7 @@ TOML_ANON_NAMESPACE_START
 		}
 	}
 
-	struct error_builder final
+	struct error_builder
 	{
 		static constexpr std::size_t buf_size = 512;
 		char buf[buf_size];
@@ -8935,7 +8935,7 @@ TOML_ANON_NAMESPACE_START
 		error_builder& operator=(error_builder&&) = delete;
 	};
 
-	struct parse_scope final
+	struct parse_scope
 	{
 		std::string_view& storage_;
 		std::string_view parent_;
@@ -9023,18 +9023,19 @@ TOML_ANON_NAMESPACE_START
 			}
 	};
 
-	struct parsed_key final
+	struct parsed_key
 	{
+		toml::source_position position;
 		std::vector<std::string> segments;
 	};
 
-	struct parsed_key_value_pair final
+	struct parsed_key_value_pair
 	{
 		parsed_key key;
 		node_ptr value;
 	};
 
-	struct parse_depth_counter final
+	struct parse_depth_counter
 	{
 		size_t& depth_;
 
@@ -9056,6 +9057,11 @@ TOML_ANON_NAMESPACE_START
 		parse_depth_counter& operator=(parse_depth_counter&&) = delete;
 	};
 
+	struct parsed_string
+	{
+		std::string value;
+		bool was_multi_line;
+	};
 }
 TOML_ANON_NAMESPACE_END;
 
@@ -9082,8 +9088,8 @@ TOML_IMPL_NAMESPACE_START
 	#if TOML_EXCEPTIONS
 		#define is_error()						false
 		#define return_after_error(...)			TOML_UNREACHABLE
-		#define assert_not_error()				(void)0
-		#define return_if_error(...)			(void)0
+		#define assert_not_error()				static_assert(true)
+		#define return_if_error(...)			static_assert(true)
 		#define return_if_error_or_eof(...)		return_if_eof(__VA_ARGS__)
 	#else
 		#define is_error()						!!err
@@ -9091,6 +9097,25 @@ TOML_IMPL_NAMESPACE_START
 		#define assert_not_error()				TOML_ASSERT(!is_error())
 		#define return_if_error(...)			do { if (is_error()) return __VA_ARGS__; } while(false)
 		#define return_if_error_or_eof(...)		do { if (is_eof() || is_error()) return __VA_ARGS__; } while(false)
+	#endif
+
+	#if defined(TOML_BREAK_AT_PARSE_ERRORS) && TOML_BREAK_AT_PARSE_ERRORS
+		#if defined(__has_builtin)
+			#if __has_builtin(__builtin_debugtrap)
+				#define parse_error_break() __builtin_debugtrap()
+			#elif __has_builtin(__debugbreak)
+				#define parse_error_break() __debugbreak()
+			#endif
+		#endif
+		#ifndef parse_error_break
+			#if TOML_MSVC || TOML_ICC
+				#define parse_error_break() __debugbreak()
+			#else
+				#define parse_error_break() TOML_ASSERT(false)
+			#endif
+		#endif
+	#else
+		#define parse_error_break() static_assert(true)
 	#endif
 
 	#define set_error_and_return(ret, ...)		\
@@ -9114,7 +9139,7 @@ TOML_IMPL_NAMESPACE_START
 
 	TOML_ABI_NAMESPACE_BOOL(TOML_EXCEPTIONS, ex, noex);
 
-	class parser final
+	class parser
 	{
 		private:
 			static constexpr size_t max_nested_values = TOML_MAX_NESTED_VALUES;
@@ -9155,6 +9180,8 @@ TOML_IMPL_NAMESPACE_START
 
 				error_builder builder{ current_scope };
 				(builder.append(reason), ...);
+
+				parse_error_break();
 
 				#if TOML_EXCEPTIONS
 					builder.finish(pos, reader.source_path());
@@ -9723,12 +9750,6 @@ TOML_IMPL_NAMESPACE_START
 
 				set_error_and_return_default("encountered end-of-file"sv);
 			}
-
-			struct parsed_string final
-			{
-				std::string value;
-				bool was_multi_line;
-			};
 
 			[[nodiscard]]
 			TOML_NEVER_INLINE
@@ -11118,6 +11139,7 @@ TOML_IMPL_NAMESPACE_START
 				push_parse_scope("key"sv);
 
 				parsed_key key;
+				key.position = current_position();
 				recording_whitespace = false;
 
 				while (!is_error())
@@ -11219,7 +11241,7 @@ TOML_IMPL_NAMESPACE_START
 				assert_or_assume(*cp == U'[');
 				push_parse_scope("table header"sv);
 
-				const auto header_begin_pos = cp->position;
+				const source_position header_begin_pos = cp->position;
 				source_position header_end_pos;
 				parsed_key key;
 				bool is_arr = false;
@@ -11378,7 +11400,7 @@ TOML_IMPL_NAMESPACE_START
 						&& !implicit_tables.empty())
 					{
 						auto tbl = &matching_node->ref_cast<table>();
-						if (auto found = find(implicit_tables, tbl))
+						if (auto found = find(implicit_tables, tbl); found && (tbl->empty() || tbl->is_homogeneous<table>()))
 						{
 							implicit_tables.erase(implicit_tables.cbegin() + (found - implicit_tables.data()));
 							tbl->source_.begin = header_begin_pos;
@@ -11389,13 +11411,19 @@ TOML_IMPL_NAMESPACE_START
 
 					//if we get here it's a redefinition error.
 					if (!is_arr && matching_node->type() == node_type::table)
-						set_error_and_return_default("cannot redefine existing table '"sv, to_sv(recording_buffer), "'"sv);
+					{
+						set_error_at(header_begin_pos, "cannot redefine existing table '"sv, to_sv(recording_buffer), "'"sv);
+						return_after_error({});
+					}
 					else
-						set_error_and_return_default(
+					{
+						set_error_at(header_begin_pos,
 							"cannot redefine existing "sv, to_sv(matching_node->type()),
 							" '"sv, to_sv(recording_buffer),
 							"' as "sv, is_arr ? "array-of-tables"sv : "table"sv
 						);
+						return_after_error({});
+					}
 				}
 			}
 
@@ -11426,9 +11454,11 @@ TOML_IMPL_NAMESPACE_START
 							dotted_key_tables.push_back(&child->ref_cast<table>());
 							child->source_ = kvp.value.get()->source_;
 						}
-						else if (!child->is_table()
-							|| !(find(dotted_key_tables, &child->ref_cast<table>()) || find(implicit_tables, &child->ref_cast<table>())))
-							set_error("cannot redefine existing "sv, to_sv(child->type()), " as dotted key-value pair"sv);
+						else if (!child->is_table() || !(
+							find(dotted_key_tables, &child->ref_cast<table>())
+							|| find(implicit_tables, &child->ref_cast<table>())
+						))
+							set_error_at(kvp.key.position, "cannot redefine existing "sv, to_sv(child->type()), " as dotted key-value pair"sv);
 						else
 							child->source_.end = kvp.value.get()->source_.end;
 
@@ -11823,6 +11853,7 @@ TOML_IMPL_NAMESPACE_START
 	#undef advance_and_return_if_error
 	#undef advance_and_return_if_error_or_eof
 	#undef assert_or_assume
+	#undef parse_error_break
 }
 TOML_IMPL_NAMESPACE_END;
 

--- a/Sources/CTOML/include/CTOML/CTOML.h
+++ b/Sources/CTOML/include/CTOML/CTOML.h
@@ -151,6 +151,9 @@ extern "C" {
 	/// Removes the element at \c index from \c array .
 	void arrayRemoveElement(CTOMLArray * array, int64_t index);
 
+	/// Convert \c array to TOML.
+	const char * _Nonnull arrayConvertToTOML(CTOMLArray * _Nonnull array);
+
 	// MARK: - Array - Value Manipulation - Insertion
 
 	/// Insert a \c int64_t into \c array .
@@ -292,6 +295,15 @@ extern "C" {
 	/// Copies \c n and returns the copy.
 	CTOMLNode * copyNode(CTOMLNode * n);
 
+	// MARK: - Date, Time, and Date Time Conversion
+	/// Convert \c date to TOML.
+	const char * _Nonnull cTOMLDateToTOML(CTOMLDate date);
+
+	/// Convert \c time to TOML.
+	const char * _Nonnull cTOMLTimeToTOML(CTOMLTime time);
+
+	/// Convert \c dateTime to TOML.
+	const char * _Nonnull cTOMLDateTimeToTOML(CTOMLDateTime dateTime);
 	#pragma clang assume_nonnull end
 
 	// MARK: - Node - Creation

--- a/Sources/TOMLKit/Encoder/TOMLEncoder.swift
+++ b/Sources/TOMLKit/Encoder/TOMLEncoder.swift
@@ -49,6 +49,7 @@ public struct TOMLEncoder {
 	///   - value: The type you want to convert into a `TOMLTable`.
 	/// - Throws: `EncodingError`.
 	/// - Returns: The generated `TOMLTable` containing the contents of `T`.
+	@_disfavoredOverload
 	public func encode<T: Encodable>(_ value: T) throws -> TOMLTable {
 		let table = TOMLTable()
 

--- a/Sources/TOMLKit/TOML Data Types/TOMLArray/TOMLArray+CollectionConformance.swift
+++ b/Sources/TOMLKit/TOML Data Types/TOMLArray/TOMLArray+CollectionConformance.swift
@@ -19,7 +19,7 @@ extension TOMLArray:
 	public var indices: Range<Index> { 0..<self.endIndex }
 
 	private func checkIndex(_ index: Index) {
-		precondition(index <= self.endIndex - 1, "TOMLArray index out of bounds")
+		precondition(index <= self.endIndex - 1, "TOMLArray index out of range")
 	}
 
 	private func isEmptyPrecondition() {
@@ -27,7 +27,7 @@ extension TOMLArray:
 	}
 
 	private func checkPastEndIndex(_ index: Index) {
-		precondition(index < self.endIndex, "Can't advance beyond self.endIndex")
+		precondition(index < self.endIndex, "Cannot advance beyond self.endIndex")
 	}
 
 	public func append(_ newElement: Element) {
@@ -74,7 +74,6 @@ extension TOMLArray:
 		return i + 1
 	}
 
-	/// Insert a value into this array or retrieve a value.
 	public subscript(index: Index) -> Element {
 		get {
 			self.checkIndex(index)

--- a/Sources/TOMLKit/TOML Data Types/TOMLArray/TOMLArray.swift
+++ b/Sources/TOMLKit/TOML Data Types/TOMLArray/TOMLArray.swift
@@ -16,8 +16,8 @@
 
 import CTOML
 
-/// An array in a TOML document.
-public class TOMLArray:
+/// An [array](https://toml.io/en/v1.0.0#array) in a TOML document.
+public final class TOMLArray:
 	Equatable,
 	Sequence,
 	ExpressibleByArrayLiteral,
@@ -32,14 +32,14 @@ public class TOMLArray:
 
 	public var tomlValue: TOMLValue { get { .init(self) } set {} }
 
-	/// The amount of elements in the array.
 	public var count: Int { arraySize(self.arrayPointer) }
 
 	/// If this array is empty.
 	public var isEmpty: Bool { arrayIsEmpty(self.arrayPointer) }
 
 	public var debugDescription: String {
-		"[\(self.map({ "\($0.debugDescription)" }).joined(separator: ", "))]"
+		String(cString: arrayConvertToTOML(self.arrayPointer))
+		// "[\(self.map({ "\($0.debugDescription)" }).joined(separator: ", "))]"
 	}
 
 	/// A pointer to the underlying `toml::array`.
@@ -54,25 +54,14 @@ public class TOMLArray:
 		self.arrayPointer = arrayCreate()
 	}
 
-	/// Creates a new `TOMLArray` using the contents of a Swift array.
-	public init(_ array: [TOMLValueConvertible]) {
-		self.arrayPointer = arrayCreate()
-		var index = 0
-
-		array.forEach({
-			$0.tomlValue.insertIntoArray(arrayPointer: self.arrayPointer, index: index)
-			index += 1
-		})
+	/// Creates a new `TOMLArray` using the contents of a Swift `Array`.
+	public convenience init(_ array: [TOMLValueConvertible]) {
+		self.init()
+		array.forEach(self.append(_:))
 	}
 
-	public required init(arrayLiteral: TOMLValueConvertible...) {
-		self.arrayPointer = arrayCreate()
-		var index = 0
-
-		arrayLiteral.forEach({
-			$0.tomlValue.insertIntoArray(arrayPointer: self.arrayPointer, index: index)
-			index += 1
-		})
+	public convenience init(arrayLiteral: TOMLValueConvertible...) {
+		self.init(arrayLiteral)
 	}
 
 	/// Remove all the elements from this array.

--- a/Sources/TOMLKit/TOML Data Types/TOMLDate&Time&DateTime.swift
+++ b/Sources/TOMLKit/TOML Data Types/TOMLDate&Time&DateTime.swift
@@ -20,8 +20,8 @@ import struct Foundation.Calendar
 import struct Foundation.Date
 import struct Foundation.DateComponents
 
-/// A date in a TOML document.
-public struct TOMLDate: Codable, CustomDebugStringConvertible, TOMLValueConvertible, Equatable {
+/// A [date](https://toml.io/en/v1.0.0#local-date) in a TOML document.
+public struct TOMLDate: Codable, Equatable, CustomDebugStringConvertible, TOMLValueConvertible {
 	public let year: Int
 	public let month: Int
 	public let day: Int
@@ -34,7 +34,7 @@ public struct TOMLDate: Codable, CustomDebugStringConvertible, TOMLValueConverti
 	public var tomlValue: TOMLValue { get { .init(self) } set {} }
 
 	public var debugDescription: String {
-		"\(self.year)-\(String(self.month).leftPadding(to: 2))-\(String(self.day).leftPadding(to: 2))"
+		String(cString: cTOMLDateToTOML(self.cTOMLDate))
 	}
 
 	public init(year: Int, month: Int, day: Int) {
@@ -76,8 +76,8 @@ public struct TOMLDate: Codable, CustomDebugStringConvertible, TOMLValueConverti
 	}
 }
 
-/// A time in a TOML document.
-public struct TOMLTime: Codable, CustomDebugStringConvertible, TOMLValueConvertible, Equatable {
+/// A [time](https://toml.io/en/v1.0.0#local-time) in a TOML document.
+public struct TOMLTime: Codable, Equatable, CustomDebugStringConvertible, TOMLValueConvertible {
 	public let hour: Int
 	public let minute: Int
 	public let second: Int
@@ -95,7 +95,7 @@ public struct TOMLTime: Codable, CustomDebugStringConvertible, TOMLValueConverti
 	}
 
 	public var debugDescription: String {
-		"\(String(self.hour).leftPadding(to: 2)):\(String(self.minute).leftPadding(to: 2)):\(String(self.second).leftPadding(to: 2)).\(String(self.nanoSecond).leftPadding(to: 9))Z"
+		String(cString: cTOMLTimeToTOML(self.cTOMLTime))
 	}
 
 	public var tomlValue: TOMLValue { get { .init(self) } set {} }
@@ -122,7 +122,7 @@ public struct TOMLTime: Codable, CustomDebugStringConvertible, TOMLValueConverti
 	}
 }
 
-/// A date and time in a TOML document.
+/// A [time offset](https://toml.io/en/v1.0.0#offset-date-time) for a `TOMLDateTime`.
 public struct TOMLTimeOffset: Codable, Equatable {
 	public let offset: Int
 
@@ -139,7 +139,8 @@ public struct TOMLTimeOffset: Codable, Equatable {
 	}
 }
 
-public struct TOMLDateTime: Codable, CustomDebugStringConvertible, TOMLValueConvertible, Equatable {
+/// A [date and time](https://toml.io/en/v1.0.0#local-date-time) in a TOML document.
+public struct TOMLDateTime: Codable, Equatable, CustomDebugStringConvertible, TOMLValueConvertible {
 	public let date: TOMLDate
 	public let time: TOMLTime
 	public internal(set) var offset: TOMLTimeOffset?
@@ -158,7 +159,7 @@ public struct TOMLDateTime: Codable, CustomDebugStringConvertible, TOMLValueConv
 	public var tomlValue: TOMLValue { get { .init(self) } set {} }
 
 	public var debugDescription: String {
-		"\(self.date.debugDescription)T\(self.time.debugDescription)"
+		String(cString: cTOMLDateTimeToTOML(self.cTOMLDateTime))
 	}
 
 	public var type: TOMLType { .dateTime }

--- a/Sources/TOMLKit/TOML Data Types/TOMLInt.swift
+++ b/Sources/TOMLKit/TOML Data Types/TOMLInt.swift
@@ -16,7 +16,7 @@
 
 import CTOML
 
-/// An integer in a TOML document.
+/// An [integer](https://toml.io/en/v1.0.0#integer) in a TOML document.
 public struct TOMLInt: ExpressibleByIntegerLiteral, Equatable, TOMLValueConvertible {
 	public var type: TOMLType { .int }
 

--- a/Sources/TOMLKit/TOML Data Types/TOMLTable/TOMLTable+CollectionFunctions.swift
+++ b/Sources/TOMLKit/TOML Data Types/TOMLTable/TOMLTable+CollectionFunctions.swift
@@ -37,7 +37,7 @@ public extension TOMLTable {
 	/// Remove the element at `key` from this table.
 	///
 	/// - Returns: `nil` if there was no value at `key`, or the value that was deleted at `key`.
-	func remove(at key: String) -> TOMLValueConvertible? {
+	@discardableResult func remove(at key: String) -> TOMLValueConvertible? {
 		if let v = self[key]?.tomlValue.tomlValuePointer {
 			let element = TOMLValue(tomlValuePointer: copyNode(v))
 			tableRemoveElement(self.tablePointer, strdup(key))

--- a/Sources/TOMLKit/TOML Data Types/TOMLTable/TOMLTable.swift
+++ b/Sources/TOMLKit/TOML Data Types/TOMLTable/TOMLTable.swift
@@ -16,8 +16,8 @@
 
 import CTOML
 
-/// A table in a TOML document.
-public class TOMLTable:
+/// A [table](https://toml.io/en/v1.0.0#table) in a TOML document.
+public final class TOMLTable:
 	Equatable,
 	ExpressibleByDictionaryLiteral,
 	CustomDebugStringConvertible,
@@ -91,9 +91,8 @@ public class TOMLTable:
 	/// - Parameters:
 	///   - dictionary: The `Dictionary` that will be used to populate the fields of this table.
 	///   - inline: Whether this table will be an [inline table](https://toml.io/en/v1.0.0#inline-table) or not.
-	public init(_ dictionary: [String: TOMLValueConvertible], inline: Bool = false) {
-		self.tablePointer = tableCreate()
-		self.inline = inline
+	public convenience init(_ dictionary: [String: TOMLValueConvertible], inline: Bool = false) {
+		self.init(inline: inline)
 		dictionary.forEach({ self[$0] = $1 })
 	}
 
@@ -111,8 +110,8 @@ public class TOMLTable:
 		self.tablePointer = table
 	}
 
-	public required init(dictionaryLiteral elements: (String, TOMLValueConvertible)...) {
-		self.tablePointer = tableCreate()
+	public required convenience init(dictionaryLiteral elements: (String, TOMLValueConvertible)...) {
+		self.init()
 		elements.forEach({ self[$0] = $1 })
 	}
 
@@ -125,14 +124,14 @@ public class TOMLTable:
 		tableClear(self.tablePointer)
 	}
 
-	/// Insert a value into this `TOMLTable`, or retrieve a value from this `TOMLTable`.
+	/// Insert a value into this `TOMLTable`, or retrieve a value.
 	public subscript(key: String) -> TOMLValueConvertible? {
 		get {
 			guard let pointer = tableGetNode(self.tablePointer, strdup(key)) else { return nil }
 			return TOMLValue(tomlValuePointer: pointer)
 		}
 		set(value) {
-			value!.tomlValue.replaceOrInsertInTable(tablePointer: self.tablePointer, key: key)
+			value?.tomlValue.replaceOrInsertInTable(tablePointer: self.tablePointer, key: key)
 		}
 	}
 

--- a/Sources/TOMLKit/TOMLParseError.swift
+++ b/Sources/TOMLKit/TOMLParseError.swift
@@ -41,7 +41,9 @@ public struct TOMLSourceRegion: Equatable, CustomDebugStringConvertible {
 		self.end = .init(cTOMLSourcePosition: cEnd)
 	}
 
-	public var debugDescription: String { "begin: \(self.begin), end: \(self.end)" }
+	public var debugDescription: String {
+		self.begin == self.end ? "at \(self.begin)" : "from \(self.begin) to \(self.end)"
+	}
 }
 
 /// An error that occurs while parsing a TOML document.
@@ -59,5 +61,5 @@ struct TOMLParseError: Error, CustomDebugStringConvertible {
 		self.source = TOMLSourceRegion(cBegin: cTOMLParseError.source.begin, cEnd: cTOMLParseError.source.end)
 	}
 
-	var debugDescription: String { "Description: \(self.description)\nSource: \(self.source)" }
+	var debugDescription: String { "\(self.description) (\(self.source))" }
 }

--- a/Sources/TOMLKit/TOMLValue/TOMLValue.swift
+++ b/Sources/TOMLKit/TOMLValue/TOMLValue.swift
@@ -46,7 +46,7 @@ public struct TOMLValue:
 		switch self.type {
 			case .table: return self.table?.debugDescription ?? ""
 			case .array: return self.array?.debugDescription ?? ""
-			case .string: return self.string ?? ""
+			case .string: return self.string != nil ? "\"" + self.string! + "\"" : ""
 			case .int:
 				return self.int != nil ? String(self.int!) : ""
 			case .double: return self.double != nil ? String(self.double!) : ""
@@ -111,9 +111,9 @@ public struct TOMLValue:
 	func replaceInArray(arrayPointer: OpaquePointer, index: Int) {
 		switch self.type {
 			case .table:
-				arrayReplaceTable(arrayPointer, Int64(index), self.table!.tomlValue.tomlValuePointer)
+				arrayReplaceTable(arrayPointer, Int64(index), self.table!.tablePointer)
 			case .array:
-				arrayReplaceArray(arrayPointer, Int64(index), self.array!.tomlValue.tomlValuePointer)
+				arrayReplaceArray(arrayPointer, Int64(index), self.array!.arrayPointer)
 			case .string:
 				self.string!.withCString({ arrayReplaceString(arrayPointer, Int64(index), $0) })
 			case .int:
@@ -133,14 +133,5 @@ public struct TOMLValue:
 			case .dateTime:
 				arrayReplaceDateTime(arrayPointer, Int64(index), self.dateTime!.cTOMLDateTime)
 		}
-	}
-
-	public subscript(index: Int) -> TOMLValue? {
-		get { self.array?[index].tomlValue }
-		set {}
-	}
-
-	public subscript(key: String) -> TOMLValue? {
-		self.table?[key]?.tomlValue
 	}
 }


### PR DESCRIPTION
### Added

-   Links to the official documentation from `TOMLInt`, `TOMLTable`, `TOMLArray`, `TOMLDate`, `TOMLTime`, `TOMLDateTime`, and `TOMLTimeOffset`.
-   [toml++](https://github.com/marzer/tomlplusplus/) is now used to format `TOMLArray`, `TOMLDate`, `TOMLTime`, and `TOMLDateTime`, when they are being printed.
-   Improved the formatting of strings in `TOMLValue.debugDescription`.
-   Setting a value in a `TOMLTable` or `TOMLArray` via a nested subscript is now possible.

```swift
tomlTable["InnerTable"]?["Int"] = 1
tomlArray[0]?[0] = "Hello, World!"
```

### Changed

-   Improved the debug output of `TOMLParseError`.

### Fixed

-   It is no longer necessary to add `.tomlValue` after the first subscript in a subscript chain.

```swift
// Before:
tomlTable["InnerTable"]?.tomlValue["InnerTable"]
tomlArray[0]?.tomlValue[0]

// After:
tomlTable["InnerTable"]?["InnerTable"]
tomlArray[0]?[0]
```

