### PR TITLE
Disable `strdup`-related deprecation warnings using `_CRT_NONSTDC_NO_WARNINGS`

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -3,65 +3,65 @@ name: "Build and Test"
 on: ["push", "pull_request"]
 
 jobs:
-  TestOnMacOS-11_0-x86_64:
-    runs-on: "macos-11.0"
-    steps:
-      - uses: "actions/checkout@v2"
-      - name: "Run tests"
-        run: |
-          sudo xcode-select -s /Applications/Xcode_12.5.app
-          swift test
-  # TestOnUbuntu-20_04-ARM:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: uraimo/run-on-arch-action@v2.0.7
-  #       with:
-  #         arch: aarch64
-  #         distro: ubuntu20.04
-  #         githubToken: ${{ secrets.GITHUB_TOKEN }}
-  #         run: |
-  #           export DEBIAN_FRONTEND=noninteractive
-  #           apt update -q
-  #           apt install -yq curl sudo
-  #           curl -s https://packagecloud.io/install/repositories/swift-arm/release/script.deb.sh | sudo bash
-  #           apt install -yq swiftlang
-  #           apt update -yq
-  #           swift test
-  TestOnUbuntu-20_04-x86_64:
-    runs-on: "ubuntu-latest"
-    steps:
-      - uses: "actions/checkout@v2"
-      - name: "Run tests"
-        run: "swift test"
-  TestOnWindows10-x86_64:
-    runs-on: "windows-latest"
-    steps:
-      - uses: "actions/checkout@v2"
-      - uses: "seanmiddleditch/gha-setup-vsdevenv@master"
-      - name: "Install swift-5.4-RELEASE"
-        run: |
-          Install-Binary -Url "https://swift.org/builds/swift-5.4-release/windows10/swift-5.4-RELEASE/swift-5.4-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
-      - name: "Set Environment Variables"
-        run: |
-          echo "SDKROOT=C:\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "DEVELOPER_DIR=C:\Library\Developer" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-      - name: "Adjust Paths"
-        run: echo "C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin;C:\Library\Swift-development\bin;C:\Library\icu-67\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - name: "Install Supporting Files"
-        shell: "cmd"
-        run: |
-          copy "%SDKROOT%\usr\share\ucrt.modulemap" "%UniversalCRTSdkDir%\Include\%UCRTVersion%\ucrt\module.modulemap"
-          copy "%SDKROOT%\usr\share\visualc.modulemap" "%VCToolsInstallDir%\include\module.modulemap"
-          copy "%SDKROOT%\usr\share\visualc.apinotes" "%VCToolsInstallDir%\include\visualc.apinotes"
-          copy "%SDKROOT%\usr\share\winsdk.modulemap" "%UniversalCRTSdkDir%\Include\%UCRTVersion%\um\module.modulemap"
-      - name: "Test"
-        run: "swift test"
-  TestBuildingOnMacOS-11_0-ARM64:
-    runs-on: "macos-11.0"
-    steps:
-      - uses: "actions/checkout@v2"
-      - name: "Run tests"
-        run: |
-          sudo xcode-select -s /Applications/Xcode_12.5.app
-          swift build --arch arm64
+    TestOnMacOS-11_0-x86_64:
+        runs-on: "macos-11.0"
+        steps:
+            - uses: "actions/checkout@v2"
+            - name: "Run tests"
+              run: |
+                  sudo xcode-select -s /Applications/Xcode_12.5.app
+                  swift test
+    # TestOnUbuntu-20_04-ARM:
+    #   runs-on: ubuntu-latest
+    #   steps:
+    #     - uses: actions/checkout@v2
+    #     - uses: uraimo/run-on-arch-action@v2.0.7
+    #       with:
+    #         arch: aarch64
+    #         distro: ubuntu20.04
+    #         githubToken: ${{ secrets.GITHUB_TOKEN }}
+    #         run: |
+    #           export DEBIAN_FRONTEND=noninteractive
+    #           apt update -q
+    #           apt install -yq curl sudo
+    #           curl -s https://packagecloud.io/install/repositories/swift-arm/release/script.deb.sh | sudo bash
+    #           apt install -yq swiftlang
+    #           apt update -yq
+    #           swift test
+    TestOnUbuntu-20_04-x86_64:
+        runs-on: "ubuntu-latest"
+        steps:
+            - uses: "actions/checkout@v2"
+            - name: "Run tests"
+              run: "swift test"
+    TestOnWindows10-x86_64:
+        runs-on: "windows-latest"
+        steps:
+            - uses: "actions/checkout@v2"
+            - uses: "seanmiddleditch/gha-setup-vsdevenv@master"
+            - name: "Install swift-5.4-RELEASE"
+              run: |
+                  Install-Binary -Url "https://swift.org/builds/swift-5.4-release/windows10/swift-5.4-RELEASE/swift-5.4-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
+            - name: "Set Environment Variables"
+              run: |
+                  echo "SDKROOT=C:\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+                  echo "DEVELOPER_DIR=C:\Library\Developer" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            - name: "Adjust Paths"
+              run: echo "C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin;C:\Library\Swift-development\bin;C:\Library\icu-67\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+            - name: "Install Supporting Files"
+              shell: "cmd"
+              run: |
+                  copy "%SDKROOT%\usr\share\ucrt.modulemap" "%UniversalCRTSdkDir%\Include\%UCRTVersion%\ucrt\module.modulemap"
+                  copy "%SDKROOT%\usr\share\visualc.modulemap" "%VCToolsInstallDir%\include\module.modulemap"
+                  copy "%SDKROOT%\usr\share\visualc.apinotes" "%VCToolsInstallDir%\include\visualc.apinotes"
+                  copy "%SDKROOT%\usr\share\winsdk.modulemap" "%UniversalCRTSdkDir%\Include\%UCRTVersion%\um\module.modulemap"
+            - name: "Test"
+              run: "swift test"
+    TestBuildingOnMacOS-11_0-ARM64:
+        runs-on: "macos-11.0"
+        steps:
+            - uses: "actions/checkout@v2"
+            - name: "Run tests"
+              run: |
+                  sudo xcode-select -s /Applications/Xcode_12.5.app
+                  swift build --arch arm64

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,4 +18,4 @@ jobs:
             - name: "Push Changes"
               env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: "git push"
+              run: "git add . && gc -m \"Run pre-commit\" && git push"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,6 +1,8 @@
 name: "Run Pre-Commit"
 
 on: "pull_request"
+permissions:
+  
 
 jobs:
     PreCommit:
@@ -17,5 +19,5 @@ jobs:
                   pre-commit run --all-files || true
             - name: "Push Changes"
               env:
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                GITHUB_TOKEN: ${{ secrets.PRE_COMMIT_TOKEN }}
               run: "git add . && git commit -m \"Run pre-commit\" && git push"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,10 +8,10 @@ jobs:
         steps:
             - uses: "actions/checkout@v2"
               with:
-                token: ${{ secrets.PRE_COMMIT_TOKEN }}
+                  token: ${{ secrets.PRE_COMMIT_TOKEN }}
             - name: "Checkout PR"
               env:
-                GITHUB_TOKEN: ${{ secrets.PRE_COMMIT_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.PRE_COMMIT_TOKEN }}
               run: "gh pr checkout ${{ github.event.pull_request.number }}"
             - name: "Run Pre-Commit"
               run: |
@@ -19,8 +19,8 @@ jobs:
                   pre-commit run --all-files || true
             - name: "Push Changes"
               env:
-                GITHUB_TOKEN: ${{ secrets.PRE_COMMIT_TOKEN }}
-              run: | 
-                git add . || true
-                git commit -m "Run pre-commit hooks." || true
-                git push || true
+                  GITHUB_TOKEN: ${{ secrets.PRE_COMMIT_TOKEN }}
+              run: |
+                  git add . || true
+                  git commit -m "Run pre-commit hooks." || true
+                  git push || true

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,8 +1,6 @@
 name: "Run Pre-Commit"
 
 on: "pull_request"
-permissions:
-  
 
 jobs:
     PreCommit:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,4 +18,4 @@ jobs:
             - name: "Push Changes"
               env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: "git add . && gc -m \"Run pre-commit\" && git push"
+              run: "git add . && git commit -m \"Run pre-commit\" && git push"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,4 +20,7 @@ jobs:
             - name: "Push Changes"
               env:
                 GITHUB_TOKEN: ${{ secrets.PRE_COMMIT_TOKEN }}
-              run: "git add . && git commit -m \"Run pre-commit\" && git push"
+              run: | 
+                git add . || true
+                git commit -m \"Run pre-commit\" || true
+                git push || true

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,7 +14,7 @@ jobs:
             - name: "Run Pre-Commit"
               run: |
                   brew bundle
-                  pre-commit run --all-files
+                  pre-commit run --all-files || true
             - name: "Push Changes"
               env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,9 +7,11 @@ jobs:
         runs-on: "macos-latest"
         steps:
             - uses: "actions/checkout@v2"
+              with:
+                token: ${{ secrets.PRE_COMMIT_TOKEN }}
             - name: "Checkout PR"
               env:
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                GITHUB_TOKEN: ${{ secrets.PRE_COMMIT_TOKEN }}
               run: "gh pr checkout ${{ github.event.pull_request.number }}"
             - name: "Run Pre-Commit"
               run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,5 +22,5 @@ jobs:
                 GITHUB_TOKEN: ${{ secrets.PRE_COMMIT_TOKEN }}
               run: | 
                 git add . || true
-                git commit -m \"Run pre-commit\" || true
+                git commit -m "Run pre-commit hooks." || true
                 git push || true

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,21 @@
+name: "Run Pre-Commit"
+
+on: "pull_request"
+
+jobs:
+    PreCommit:
+        runs-on: "macos-latest"
+        steps:
+            - uses: "actions/checkout@v2"
+            - name: "Checkout PR"
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: "gh pr checkout ${{ github.event.pull_request.number }}"
+            - name: "Run Pre-Commit"
+              run: |
+                  brew bundle
+                  pre-commit run --all-files
+            - name: "Push Changes"
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: "git push"

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,3 @@ xcuserdata/
 /.swiftpm
 Package.resolved
 Brewfile.lock.json
-Examples/ReadArchive/.swiftpm
-Examples/ReadArchive/.build

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
 			cxxSettings: [
 				.define("TOML_LARGE_FILES", to: "1"),
 				.define("TOML_EXCEPTIONS", to: "1"),
-                .define("_CRT_NONSTDC_NO_WARNINGS", .when(platforms: [.windows])),
+				.define("_CRT_NONSTDC_NO_WARNINGS", .when(platforms: [.windows])),
 			]
 		),
 		.target(

--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,7 @@ let package = Package(
 			cxxSettings: [
 				.define("TOML_LARGE_FILES", to: "1"),
 				.define("TOML_EXCEPTIONS", to: "1"),
+                .define("_CRT_NONSTDC_NO_WARNINGS", .when(platforms: [.windows])),
 			]
 		),
 		.target(

--- a/Sources/CTOML/Sources/Array.cpp
+++ b/Sources/CTOML/Sources/Array.cpp
@@ -175,8 +175,6 @@ extern "C" {
 	void arrayReplaceTable(CTOMLArray * array, int64_t index, CTOMLTable * _Nonnull table) {
 		auto arr = reinterpret_cast<toml::array *>(array);
 
-		auto a = arr->get(0);
-
 		if (arr->get(index)) {
 			arr->erase(arr->cbegin() + index);
 		}

--- a/Sources/CTOML/Sources/Table.cpp
+++ b/Sources/CTOML/Sources/Table.cpp
@@ -183,7 +183,7 @@ extern "C" {
 
 	/// Remove the element at \c key from \c table .
 	void tableRemoveElement(CTOMLTable * table, const char * key) {
-		auto t = reinterpret_cast<toml::table *>(table)->erase(key);
+		reinterpret_cast<toml::table *>(table)->erase(key);
 	}
 
 	// MARK: - Table Conversion

--- a/Sources/TOMLKit/TOML Data Types/TOMLArray/TOMLArray.swift
+++ b/Sources/TOMLKit/TOML Data Types/TOMLArray/TOMLArray.swift
@@ -70,7 +70,7 @@ public final class TOMLArray:
 	}
 
 	func insertIntoTable(tablePointer: OpaquePointer, key: String) {
-		tableInsertArray(tablePointer, strdup(key), self.arrayPointer)
+		tableInsertArray(tablePointer, key, self.arrayPointer)
 	}
 
 	func insertIntoArray(arrayPointer: OpaquePointer, index: Int) {

--- a/Sources/TOMLKit/TOML Data Types/TOMLInt.swift
+++ b/Sources/TOMLKit/TOML Data Types/TOMLInt.swift
@@ -59,7 +59,7 @@ public struct TOMLInt: ExpressibleByIntegerLiteral, Equatable, TOMLValueConverti
 	}
 
 	public func insertIntoTable(tablePointer: OpaquePointer, key: String) {
-		tableInsertInt(tablePointer, strdup(key), Int64(self.value), self.options.rawValue)
+		tableInsertInt(tablePointer, key, Int64(self.value), self.options.rawValue)
 	}
 }
 

--- a/Sources/TOMLKit/TOML Data Types/TOMLTable/TOMLTable+CollectionFunctions.swift
+++ b/Sources/TOMLKit/TOML Data Types/TOMLTable/TOMLTable+CollectionFunctions.swift
@@ -18,7 +18,7 @@ import CTOML
 
 public extension TOMLTable {
 	func contains(key: String) -> Bool {
-		tableContains(self.tablePointer, strdup(key))
+		tableContains(self.tablePointer, key)
 	}
 
 	func contains(element: TOMLValueConvertible) -> Bool {
@@ -40,7 +40,7 @@ public extension TOMLTable {
 	@discardableResult func remove(at key: String) -> TOMLValueConvertible? {
 		if let v = self[key]?.tomlValue.tomlValuePointer {
 			let element = TOMLValue(tomlValuePointer: copyNode(v))
-			tableRemoveElement(self.tablePointer, strdup(key))
+			tableRemoveElement(self.tablePointer, key)
 			return element
 		} else {
 			return nil

--- a/Sources/TOMLKit/TOML Data Types/TOMLTable/TOMLTable.swift
+++ b/Sources/TOMLKit/TOML Data Types/TOMLTable/TOMLTable.swift
@@ -127,8 +127,8 @@ public final class TOMLTable:
 	/// Insert a value into this `TOMLTable`, or retrieve a value.
 	public subscript(key: String) -> TOMLValueConvertible? {
 		get {
-			guard let pointer = tableGetNode(self.tablePointer, strdup(key)) else { return nil }
-			return TOMLValue(tomlValuePointer: pointer)
+			guard let pointer = tableGetNode(self.tablePointer, key) else { return nil }
+			return TOMLValue(tomlValuePointer: pointer)	
 		}
 		set(value) {
 			value?.tomlValue.replaceOrInsertInTable(tablePointer: self.tablePointer, key: key)
@@ -152,7 +152,7 @@ public final class TOMLTable:
 	}
 
 	func insertIntoTable(tablePointer: OpaquePointer, key: String) {
-		tableInsertTable(tablePointer, strdup(key), self.tablePointer)
+		tableInsertTable(tablePointer, key, self.tablePointer)
 	}
 
 	func insertIntoArray(arrayPointer: OpaquePointer, index: Int) {

--- a/Sources/TOMLKit/TOML Data Types/TOMLTable/TOMLTable.swift
+++ b/Sources/TOMLKit/TOML Data Types/TOMLTable/TOMLTable.swift
@@ -128,7 +128,7 @@ public final class TOMLTable:
 	public subscript(key: String) -> TOMLValueConvertible? {
 		get {
 			guard let pointer = tableGetNode(self.tablePointer, key) else { return nil }
-			return TOMLValue(tomlValuePointer: pointer)	
+			return TOMLValue(tomlValuePointer: pointer)
 		}
 		set(value) {
 			value?.tomlValue.replaceOrInsertInTable(tablePointer: self.tablePointer, key: key)

--- a/Sources/TOMLKit/TOMLValue/TOMLValue+Initializers.swift
+++ b/Sources/TOMLKit/TOMLValue/TOMLValue+Initializers.swift
@@ -43,7 +43,7 @@ public extension TOMLValue {
 	}
 
 	init(stringLiteral value: String) {
-		self.tomlValuePointer = nodeFromString(strdup(value))
+		self.tomlValuePointer = nodeFromString(value)
 	}
 
 	init(_ value: TOMLDate) {

--- a/Sources/TOMLKit/TOMLValue/TOMLValue.swift
+++ b/Sources/TOMLKit/TOMLValue/TOMLValue.swift
@@ -47,8 +47,7 @@ public struct TOMLValue:
 			case .table: return self.table?.debugDescription ?? ""
 			case .array: return self.array?.debugDescription ?? ""
 			case .string: return self.string != nil ? "\"" + self.string! + "\"" : ""
-			case .int:
-				return self.int != nil ? String(self.int!) : ""
+			case .int: return self.int != nil ? String(self.int!) : ""
 			case .double: return self.double != nil ? String(self.double!) : ""
 			case .bool: return self.bool != nil ? String(self.bool!) : ""
 			case .date: return self.date?.debugDescription ?? ""

--- a/Sources/TOMLKit/TOMLValue/TOMLValue.swift
+++ b/Sources/TOMLKit/TOMLValue/TOMLValue.swift
@@ -81,17 +81,17 @@ public struct TOMLValue:
 	///   - key:
 	func insertIntoTable(tablePointer: OpaquePointer, key: String) {
 		if let t = self.tomlInt {
-			tableInsertInt(tablePointer, strdup(key), Int64(t.value), t.options.rawValue)
+			tableInsertInt(tablePointer, key, Int64(t.value), t.options.rawValue)
 		} else {
-			tableInsertNode(tablePointer, strdup(key), self.tomlValuePointer)
+			tableInsertNode(tablePointer, key, self.tomlValuePointer)
 		}
 	}
 
 	func replaceOrInsertInTable(tablePointer: OpaquePointer, key: String) {
 		if let t = self.tomlInt {
-			tableReplaceOrInsertInt(tablePointer, strdup(key), Int64(t.value), t.options.rawValue)
+			tableReplaceOrInsertInt(tablePointer, key, Int64(t.value), t.options.rawValue)
 		} else {
-			tableReplaceOrInsertNode(tablePointer, strdup(key), self.tomlValuePointer)
+			tableReplaceOrInsertNode(tablePointer, key, self.tomlValuePointer)
 		}
 	}
 


### PR DESCRIPTION
- Disable `strdup`-related [deprecation warnings](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4996?view=msvc-160#posix-function-names) using `_CRT_NONSTDC_NO_WARNINGS`.
- Remove `strdup` usage from Swift source files.
- Add pre-commit action.
