### PR TITLE
Use `codingPath` in TOMLEncoder and TOMLDecoder to improve thrown `DecodingError`s

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -12,6 +12,7 @@
 --wraparguments before-first
 --wrapparameters before-first
 --disable trailingClosures, typeSugar
+--maxwidth 120
 --header "Copyright (c) 2022 Jeff Lebrun \n\n \
 Licensed under the MIT License. \n\n \
 The full text of the license can be found in the file named LICENSE.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.1](https://github.com/LebJe/TOMLKit/releases/tag/0.5.1) - 2022-03-31
 
 ### Fixed
-* [Fatal crash during decoding](https://github.com/LebJe/TOMLKit/issues/12) (#13 by @stackotter)
 
-* Fix pre-commit workflows by replacing `git://...` URL with a `https://` one.
+-   [Fatal crash during decoding](https://github.com/LebJe/TOMLKit/issues/12) (#13 by @stackotter)
+
+-   Fix pre-commit workflows by replacing `git://...` URL with a `https://` one.
 
 ## [0.5.0](https://github.com/LebJe/TOMLKit/releases/tag/0.5.0) - 2022-01-18
 

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,10 @@ let package = Package(
 		),
 		.testTarget(
 			name: "TOMLKitTests",
-			dependencies: ["TOMLKit", .product(name: "Checkit", package: "Checkit") /* .product(name: "CustomDump", package: "swift-custom-dump") */ ]
+			dependencies: [
+				"TOMLKit",
+				.product(name: "Checkit", package: "Checkit"), /* .product(name: "CustomDump", package: "swift-custom-dump") */
+			]
 		),
 	],
 	cLanguageStandard: .c99,

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -33,7 +33,10 @@ let package = Package(
 		),
 		.testTarget(
 			name: "TOMLKitTests",
-			dependencies: ["TOMLKit", .product(name: "Checkit", package: "Checkit") /* .product(name: "CustomDump", package: "swift-custom-dump") */ ]
+			dependencies: [
+				"TOMLKit",
+				.product(name: "Checkit", package: "Checkit"), /* .product(name: "CustomDump", package: "swift-custom-dump") */
+			]
 		),
 	],
 	cLanguageStandard: .c99,

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ TOMLKit is a [Swift](https://swift.org) wrapper around [toml++](https://github.c
     -   [Licenses](#licenses)
     -   [Contributing](#contributing)
 
-<!-- Added by: lebje, at: Tue Jan 18 10:50:45 EST 2022 -->
+<!-- Added by: lebje, at: Fri Apr  1 15:58:35 EDT 2022 -->
 
 <!--te-->
 

--- a/Sources/TOMLKit/Decoder/InternalTOMLDecoder.swift
+++ b/Sources/TOMLKit/Decoder/InternalTOMLDecoder.swift
@@ -12,9 +12,15 @@ final class InternalTOMLDecoder: Decoder {
 	var dataDecoder: (TOMLValueConvertible) -> Data?
 
 	let tomlValue: TOMLValue
-	init(_ tomlValue: TOMLValue, userInfo: [CodingUserInfoKey: Any] = [:], dataDecoder: @escaping (TOMLValueConvertible) -> Data?) {
+	init(
+		_ tomlValue: TOMLValue,
+		userInfo: [CodingUserInfoKey: Any] = [:],
+		codingPath: [CodingKey] = [],
+		dataDecoder: @escaping (TOMLValueConvertible) -> Data?
+	) {
 		self.tomlValue = tomlValue
 		self.userInfo = userInfo
+		self.codingPath = codingPath
 		self.dataDecoder = dataDecoder
 	}
 
@@ -33,7 +39,10 @@ final class InternalTOMLDecoder: Decoder {
 		guard let array = self.tomlValue.array else {
 			throw DecodingError.typeMismatch(
 				TOMLArray.self,
-				DecodingError.Context(codingPath: self.codingPath, debugDescription: "Expected a TOMLArray but found a \(self.tomlValue.type) instead.")
+				DecodingError.Context(
+					codingPath: self.codingPath,
+					debugDescription: "Expected a TOMLArray but found a \(self.tomlValue.type.description) instead."
+				)
 			)
 		}
 		return UDC(array, codingPath: self.codingPath, userInfo: self.userInfo, dataDecoder: self.dataDecoder)

--- a/Sources/TOMLKit/Decoder/KeyedDecodingContainerProtocol.swift
+++ b/Sources/TOMLKit/Decoder/KeyedDecodingContainerProtocol.swift
@@ -9,7 +9,14 @@ import struct Foundation.Data
 extension InternalTOMLDecoder.KDC {
 	private func decodeInt(key: Key) throws -> Int {
 		guard let i = self.tomlValue.table?[key.stringValue]?.int else {
-			throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.codingPath, debugDescription: "A \"Int\" does not exist at \"\(key.stringValue)\" in the TOML table."))
+			throw DecodingError.keyNotFound(
+				key,
+				DecodingError
+					.Context(
+						codingPath: self.codingPath + key,
+						debugDescription: "A \"Int\" does not exist at \"\(key.stringValue)\" in the TOML table."
+					)
+			)
 		}
 
 		return i
@@ -25,7 +32,14 @@ extension InternalTOMLDecoder.KDC {
 
 	func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool {
 		guard let b = self.tomlValue.table?[key.stringValue]?.bool else {
-			throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.codingPath, debugDescription: "A \"\(type)\" does not exist at \"\(key.stringValue)\" in the TOML table."))
+			throw DecodingError.keyNotFound(
+				key,
+				DecodingError
+					.Context(
+						codingPath: self.codingPath + key,
+						debugDescription: "A \"\(type)\" does not exist at \"\(key.stringValue)\" in the TOML table."
+					)
+			)
 		}
 
 		return b
@@ -33,7 +47,14 @@ extension InternalTOMLDecoder.KDC {
 
 	func decode(_ type: String.Type, forKey key: Key) throws -> String {
 		guard let s = self.tomlValue.table?[key.stringValue]?.string else {
-			throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.codingPath, debugDescription: "A \"\(type)\" does not exist at \"\(key.stringValue)\" in the TOML table."))
+			throw DecodingError.keyNotFound(
+				key,
+				DecodingError
+					.Context(
+						codingPath: self.codingPath + key,
+						debugDescription: "A \"\(type)\" does not exist at \"\(key.stringValue)\" in the TOML table."
+					)
+			)
 		}
 
 		return s
@@ -41,7 +62,14 @@ extension InternalTOMLDecoder.KDC {
 
 	func decode(_ type: Double.Type, forKey key: Key) throws -> Double {
 		guard let d = self.tomlValue.table?[key.stringValue]?.double else {
-			throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.codingPath, debugDescription: "A \"\(type)\" does not exist at \"\(key.stringValue)\" in the TOML table."))
+			throw DecodingError.keyNotFound(
+				key,
+				DecodingError
+					.Context(
+						codingPath: self.codingPath + key,
+						debugDescription: "A \"\(type)\" does not exist at \"\(key.stringValue)\" in the TOML table."
+					)
+			)
 		}
 
 		return d
@@ -49,7 +77,14 @@ extension InternalTOMLDecoder.KDC {
 
 	func decode(_ type: Float.Type, forKey key: Key) throws -> Float {
 		guard let d = self.tomlValue.table?[key.stringValue]?.double else {
-			throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.codingPath, debugDescription: "A \"\(type)\" does not exist at \"\(key.stringValue)\" in the TOML table."))
+			throw DecodingError.keyNotFound(
+				key,
+				DecodingError
+					.Context(
+						codingPath: self.codingPath + key,
+						debugDescription: "A \"\(type)\" does not exist at \"\(key.stringValue)\" in the TOML table."
+					)
+			)
 		}
 
 		return Float(d)
@@ -100,56 +135,126 @@ extension InternalTOMLDecoder.KDC {
 		switch self.tomlValue.table?[key.stringValue]?.type {
 			case .time:
 				guard let value = self.tomlValue.table?[key.stringValue]?.time as? T else {
-					throw DecodingError.typeMismatch(TOMLTime.self, DecodingError.Context(codingPath: self.codingPath, debugDescription: "The type (\(type)) being decoded is not a \(TOMLTime.self)"))
+					throw DecodingError.typeMismatch(
+						TOMLTime.self,
+						DecodingError
+							.Context(
+								codingPath: self.codingPath + key,
+								debugDescription: "Expected to decode a \(self.tomlValue.table?[key.stringValue]?.type.description ?? "") type at \(key.stringValue) but found a \(T.self) instead."
+							)
+					)
 				}
 
 				return value
 			case .date:
 				guard let value = self.tomlValue.table?[key.stringValue]?.date as? T else {
-					throw DecodingError.typeMismatch(TOMLDate.self, DecodingError.Context(codingPath: self.codingPath, debugDescription: "The type (\(type)) being decoded is not a \(TOMLDate.self)"))
+					throw DecodingError.typeMismatch(
+						TOMLDate.self,
+						DecodingError
+							.Context(
+								codingPath: self.codingPath + key,
+								debugDescription: "Expected to decode a \(self.tomlValue.table?[key.stringValue]?.type.description ?? "") type at \(key.stringValue) but found a \(T.self) instead."
+							)
+					)
 				}
 
 				return value
 			case .dateTime:
 				guard let value = self.tomlValue.table?[key.stringValue]?.dateTime as? T else {
-					throw DecodingError.typeMismatch(TOMLDateTime.self, DecodingError.Context(codingPath: self.codingPath, debugDescription: "The type (\(type)) being decoded is not a \(TOMLDateTime.self)"))
+					throw DecodingError.typeMismatch(
+						TOMLDateTime.self,
+						DecodingError
+							.Context(
+								codingPath: self.codingPath + key,
+								debugDescription: "Expected to decode a \(self.tomlValue.table?[key.stringValue]?.type.description ?? "") type at \(key.stringValue) but found a \(T.self) instead."
+							)
+					)
 				}
 
 				return value
 			case .none:
-				throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.codingPath, debugDescription: "The key \"\(key.stringValue)\" was not found in the TOML table."))
+				throw DecodingError.keyNotFound(
+					key,
+					DecodingError
+						.Context(
+							codingPath: self.codingPath + key,
+							debugDescription: "The key \"\(key.stringValue)\" was not found in the TOML table."
+						)
+				)
 			default:
 				if type is Data.Type, let value = self.tomlValue.table?[key.stringValue] {
 					guard let data = self.dataDecoder(value) else {
-						throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Unable to decode Data from the string: \"\(value)\". Key: \(key.stringValue)"))
+						throw DecodingError.dataCorrupted(DecodingError.Context(
+							codingPath: self.codingPath + key,
+							debugDescription: "Unable to decode Data from the string: \"\(value)\". Key: \(key.stringValue)"
+						))
 					}
 
 					return data as! T
 				} else {
 					guard let value = self.tomlValue.table?[key.stringValue]?.tomlValue else {
-						throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.codingPath, debugDescription: "The key \"\(key.stringValue)\" was not found in the TOML table."))
+						throw DecodingError.keyNotFound(
+							key,
+							DecodingError
+								.Context(
+									codingPath: self.codingPath + key,
+									debugDescription: "The key \"\(key.stringValue)\" was not found in the TOML table."
+								)
+						)
 					}
 
-					let decoder = InternalTOMLDecoder(value, userInfo: self.userInfo, dataDecoder: self.dataDecoder)
+					let decoder = InternalTOMLDecoder(
+						value,
+						userInfo: self.userInfo,
+						codingPath: self.codingPath + key,
+						dataDecoder: self.dataDecoder
+					)
 					return try T(from: decoder)
 				}
 		}
 	}
 
-	func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey {
+	func nestedContainer<NestedKey>(
+		keyedBy type: NestedKey.Type,
+		forKey key: Key
+	) throws -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey {
 		guard let value = self.tomlValue.table?[key.stringValue]?.table?.tomlValue else {
-			throw DecodingError.typeMismatch(TOMLTable.self, DecodingError.Context(codingPath: self.codingPath, debugDescription: "Expected a TOMLTable but found a \(self.tomlValue.table?[key.stringValue]?.type.rawValue ?? "No type") instead."))
+			throw DecodingError.typeMismatch(
+				TOMLTable.self,
+				DecodingError
+					.Context(
+						codingPath: self.codingPath + key,
+						debugDescription: "Expected a TOMLTable but found a \(self.tomlValue.table?[key.stringValue]?.type.rawValue ?? "No type") instead."
+					)
+			)
 		}
 
-		return KeyedDecodingContainer<NestedKey>(InternalTOMLDecoder.KDC<NestedKey>(tomlValue: value, codingPath: self.codingPath, userInfo: self.userInfo, dataDecoder: self.dataDecoder))
+		return KeyedDecodingContainer<NestedKey>(InternalTOMLDecoder.KDC<NestedKey>(
+			tomlValue: value,
+			codingPath: self.codingPath + key,
+			userInfo: self.userInfo,
+			dataDecoder: self.dataDecoder
+		))
 	}
 
 	func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
 		guard let array = self.tomlValue.table?[key.stringValue]?.array else {
-			throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.codingPath, debugDescription: "An array does not exist at \"\(key.stringValue)\" in the TOML table."))
+			throw DecodingError.keyNotFound(
+				key,
+				DecodingError
+					.Context(
+						codingPath: self.codingPath + key,
+						debugDescription: "An array does not exist at \"\(key.stringValue)\" in the TOML table."
+					)
+			)
 		}
 
-		return InternalTOMLDecoder.UDC(array, codingPath: self.codingPath, userInfo: self.userInfo, dataDecoder: self.dataDecoder)
+		return InternalTOMLDecoder.UDC(
+			array,
+			codingPath: self.codingPath + key,
+			userInfo: self.userInfo,
+			dataDecoder: self.dataDecoder
+		)
 	}
 
 	func superDecoder() throws -> Decoder {

--- a/Sources/TOMLKit/Decoder/SingleValueDecodingContainer.swift
+++ b/Sources/TOMLKit/Decoder/SingleValueDecodingContainer.swift
@@ -13,7 +13,13 @@ extension InternalTOMLDecoder.SVDC {
 
 	func decode(_ type: Bool.Type) throws -> Bool {
 		guard let b = self.tomlValue.bool else {
-			throw DecodingError.typeMismatch(Bool.self, DecodingError.Context(codingPath: self.codingPath, debugDescription: "A \"\(type)\" does not exist in this table."))
+			throw DecodingError.typeMismatch(
+				Bool.self,
+				DecodingError.Context(
+					codingPath: self.codingPath,
+					debugDescription: "Cannot decode \"\(type)\" from \(self.tomlValue)"
+				)
+			)
 		}
 
 		return b
@@ -21,7 +27,13 @@ extension InternalTOMLDecoder.SVDC {
 
 	func decode(_ type: String.Type) throws -> String {
 		guard let s = self.tomlValue.string else {
-			throw DecodingError.typeMismatch(String.self, DecodingError.Context(codingPath: self.codingPath, debugDescription: "A \"\(type)\" does not exist in this table."))
+			throw DecodingError.typeMismatch(
+				String.self,
+				DecodingError.Context(
+					codingPath: self.codingPath,
+					debugDescription: "Cannot decode \"\(type)\" from \(self.tomlValue)"
+				)
+			)
 		}
 
 		return s
@@ -29,7 +41,13 @@ extension InternalTOMLDecoder.SVDC {
 
 	func decode(_ type: Double.Type) throws -> Double {
 		guard let d = self.tomlValue.double else {
-			throw DecodingError.typeMismatch(Double.self, DecodingError.Context(codingPath: self.codingPath, debugDescription: "A \"\(type)\" does not exist in this table."))
+			throw DecodingError.typeMismatch(
+				Double.self,
+				DecodingError.Context(
+					codingPath: self.codingPath,
+					debugDescription: "Cannot decode \"\(type)\" from \(self.tomlValue)"
+				)
+			)
 		}
 
 		return d
@@ -37,7 +55,13 @@ extension InternalTOMLDecoder.SVDC {
 
 	func decode(_ type: Float.Type) throws -> Float {
 		guard let d = self.tomlValue.double else {
-			throw DecodingError.typeMismatch(Float.self, DecodingError.Context(codingPath: self.codingPath, debugDescription: "A \"\(type)\" does not exist in this table."))
+			throw DecodingError.typeMismatch(
+				Float.self,
+				DecodingError.Context(
+					codingPath: self.codingPath,
+					debugDescription: "Cannot decode \"\(type)\" from \(self.tomlValue)"
+				)
+			)
 		}
 
 		return Float(d)
@@ -45,7 +69,13 @@ extension InternalTOMLDecoder.SVDC {
 
 	func decode(_ type: Int.Type) throws -> Int {
 		guard let i = self.tomlValue.int else {
-			throw DecodingError.typeMismatch(Int.self, DecodingError.Context(codingPath: self.codingPath, debugDescription: "A \"\(type)\" does not exist in this table."))
+			throw DecodingError.typeMismatch(
+				Int.self,
+				DecodingError.Context(
+					codingPath: self.codingPath,
+					debugDescription: "Cannot decode \"\(type)\" from \(self.tomlValue)"
+				)
+			)
 		}
 
 		return i
@@ -53,7 +83,13 @@ extension InternalTOMLDecoder.SVDC {
 
 	func decode(_ type: Int8.Type) throws -> Int8 {
 		guard let i = self.tomlValue.int else {
-			throw DecodingError.typeMismatch(type, DecodingError.Context(codingPath: self.codingPath, debugDescription: "A \"\(type)\" does not exist in this table."))
+			throw DecodingError.typeMismatch(
+				type,
+				DecodingError.Context(
+					codingPath: self.codingPath,
+					debugDescription: "Cannot decode \"\(type)\" from \(self.tomlValue)"
+				)
+			)
 		}
 
 		return type.init(i)
@@ -61,7 +97,13 @@ extension InternalTOMLDecoder.SVDC {
 
 	func decode(_ type: Int16.Type) throws -> Int16 {
 		guard let i = self.tomlValue.int else {
-			throw DecodingError.typeMismatch(type, DecodingError.Context(codingPath: self.codingPath, debugDescription: "A \"\(type)\" does not exist in this table."))
+			throw DecodingError.typeMismatch(
+				type,
+				DecodingError.Context(
+					codingPath: self.codingPath,
+					debugDescription: "Cannot decode \"\(type)\" from \(self.tomlValue)"
+				)
+			)
 		}
 
 		return type.init(i)
@@ -69,7 +111,13 @@ extension InternalTOMLDecoder.SVDC {
 
 	func decode(_ type: Int32.Type) throws -> Int32 {
 		guard let i = self.tomlValue.int else {
-			throw DecodingError.typeMismatch(type, DecodingError.Context(codingPath: self.codingPath, debugDescription: "A \"\(type)\" does not exist in this table."))
+			throw DecodingError.typeMismatch(
+				type,
+				DecodingError.Context(
+					codingPath: self.codingPath,
+					debugDescription: "Cannot decode \"\(type)\" from \(self.tomlValue)"
+				)
+			)
 		}
 
 		return type.init(i)
@@ -77,7 +125,13 @@ extension InternalTOMLDecoder.SVDC {
 
 	func decode(_ type: Int64.Type) throws -> Int64 {
 		guard let i = self.tomlValue.int else {
-			throw DecodingError.typeMismatch(type, DecodingError.Context(codingPath: self.codingPath, debugDescription: "A \"\(type)\" does not exist in this table."))
+			throw DecodingError.typeMismatch(
+				type,
+				DecodingError.Context(
+					codingPath: self.codingPath,
+					debugDescription: "Cannot decode \"\(type)\" from \(self.tomlValue)"
+				)
+			)
 		}
 
 		return type.init(i)
@@ -85,7 +139,13 @@ extension InternalTOMLDecoder.SVDC {
 
 	func decode(_ type: UInt.Type) throws -> UInt {
 		guard let i = self.tomlValue.int else {
-			throw DecodingError.typeMismatch(type, DecodingError.Context(codingPath: self.codingPath, debugDescription: "A \"\(type)\" does not exist in this table."))
+			throw DecodingError.typeMismatch(
+				type,
+				DecodingError.Context(
+					codingPath: self.codingPath,
+					debugDescription: "Cannot decode \"\(type)\" from \(self.tomlValue)"
+				)
+			)
 		}
 
 		return type.init(i)
@@ -93,7 +153,13 @@ extension InternalTOMLDecoder.SVDC {
 
 	func decode(_ type: UInt8.Type) throws -> UInt8 {
 		guard let i = self.self.tomlValue.int else {
-			throw DecodingError.typeMismatch(type, DecodingError.Context(codingPath: self.codingPath, debugDescription: "A \"\(type)\" does not exist in this table."))
+			throw DecodingError.typeMismatch(
+				type,
+				DecodingError.Context(
+					codingPath: self.codingPath,
+					debugDescription: "Cannot decode \"\(type)\" from \(self.tomlValue)"
+				)
+			)
 		}
 
 		return type.init(i)
@@ -101,7 +167,13 @@ extension InternalTOMLDecoder.SVDC {
 
 	func decode(_ type: UInt16.Type) throws -> UInt16 {
 		guard let i = self.tomlValue.int else {
-			throw DecodingError.typeMismatch(type, DecodingError.Context(codingPath: self.codingPath, debugDescription: "A \"\(type)\" does not exist in this table."))
+			throw DecodingError.typeMismatch(
+				type,
+				DecodingError.Context(
+					codingPath: self.codingPath,
+					debugDescription: "Cannot decode \"\(type)\" from \(self.tomlValue)"
+				)
+			)
 		}
 
 		return type.init(i)
@@ -109,7 +181,13 @@ extension InternalTOMLDecoder.SVDC {
 
 	func decode(_ type: UInt32.Type) throws -> UInt32 {
 		guard let i = self.tomlValue.int else {
-			throw DecodingError.typeMismatch(type, DecodingError.Context(codingPath: self.codingPath, debugDescription: "A \"\(type)\" does not exist in this table."))
+			throw DecodingError.typeMismatch(
+				type,
+				DecodingError.Context(
+					codingPath: self.codingPath,
+					debugDescription: "Cannot decode \"\(type)\" from \(self.tomlValue)"
+				)
+			)
 		}
 
 		return type.init(i)
@@ -117,20 +195,29 @@ extension InternalTOMLDecoder.SVDC {
 
 	func decode(_ type: UInt64.Type) throws -> UInt64 {
 		guard let i = self.tomlValue.int else {
-			throw DecodingError.typeMismatch(type, DecodingError.Context(codingPath: self.codingPath, debugDescription: "A \"\(type)\" does not exist in this table."))
+			throw DecodingError.typeMismatch(
+				type,
+				DecodingError.Context(
+					codingPath: self.codingPath,
+					debugDescription: "Cannot decode \"\(type)\" from \(self.tomlValue)"
+				)
+			)
 		}
 
 		return type.init(i)
 	}
 
 	func decode<T>(_ type: T.Type) throws -> T where T: Decodable {
-		let decoder = InternalTOMLDecoder(self.tomlValue, dataDecoder: self.dataDecoder)
+		let decoder = InternalTOMLDecoder(self.tomlValue, codingPath: self.codingPath, dataDecoder: self.dataDecoder)
 
 		if type is Data.Type {
 			if let data = self.dataDecoder(self.tomlValue) {
 				return data as! T
 			} else {
-				throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Unable to decode Data from: \"\(self.tomlValue.debugDescription)\"."))
+				throw DecodingError.dataCorrupted(DecodingError.Context(
+					codingPath: self.codingPath,
+					debugDescription: "Unable to decode Data from: \"\(self.tomlValue.debugDescription)\"."
+				))
 			}
 		} else {
 			return try T(from: decoder)

--- a/Sources/TOMLKit/Encoder/InternalTOMLEncoder.swift
+++ b/Sources/TOMLKit/Encoder/InternalTOMLEncoder.swift
@@ -35,11 +35,13 @@ final class InternalTOMLEncoder: Encoder {
 	func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key: CodingKey {
 		switch self.tomlValueOrArray {
 			case let .left(value):
+				var c: [CodingKey] = []
+				if let k = self.parentKey { c.append(k) }
 				return KeyedEncodingContainer(
 					KEC(
 						value,
 						parentKey: self.parentKey,
-						codingPath: self.codingPath,
+						codingPath: self.codingPath + c,
 						userInfo: self.userInfo,
 						dataEncoder: self.dataEncoder
 					)
@@ -51,7 +53,7 @@ final class InternalTOMLEncoder: Encoder {
 					KEC(
 						array[index].tomlValue,
 						parentKey: self.parentKey,
-						codingPath: self.codingPath,
+						codingPath: self.codingPath + TOMLCodingKey(index: index),
 						userInfo: self.userInfo,
 						dataEncoder: self.dataEncoder
 					)
@@ -66,7 +68,7 @@ final class InternalTOMLEncoder: Encoder {
 					value.table?[parentKey.stringValue] = TOMLArray()
 					return UEC(
 						value.table![parentKey.stringValue]!.array!,
-						codingPath: self.codingPath,
+						codingPath: self.codingPath + parentKey,
 						userInfo: self.userInfo,
 						dataEncoder: self.dataEncoder
 					)
@@ -74,7 +76,7 @@ final class InternalTOMLEncoder: Encoder {
 					containerArray[index] = TOMLArray()
 					return UEC(
 						containerArray[index].array!,
-						codingPath: self.codingPath,
+						codingPath: self.codingPath + TOMLCodingKey(index: index),
 						userInfo: self.userInfo,
 						dataEncoder: self.dataEncoder
 					)

--- a/Sources/TOMLKit/Encoder/KeyedEncodingContainer.swift
+++ b/Sources/TOMLKit/Encoder/KeyedEncodingContainer.swift
@@ -164,7 +164,7 @@ extension InternalTOMLEncoder.KEC {
 				let encoder = InternalTOMLEncoder(
 					.left(self.tomlValue.table![parentKey.stringValue]!.table!.tomlValue),
 					parentKey: key,
-					codingPath: self.codingPath,
+					codingPath: self.codingPath + key,
 					userInfo: self.userInfo,
 					dataEncoder: self.dataEncoder
 				)
@@ -173,7 +173,7 @@ extension InternalTOMLEncoder.KEC {
 				let encoder = InternalTOMLEncoder(
 					.left(self.tomlValue),
 					parentKey: key,
-					codingPath: self.codingPath,
+					codingPath: self.codingPath + key,
 					userInfo: self.userInfo,
 					dataEncoder: self.dataEncoder
 				)
@@ -182,13 +182,15 @@ extension InternalTOMLEncoder.KEC {
 		}
 	}
 
-	func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey {
+	func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey>
+		where NestedKey: CodingKey
+	{
 		if let parentKey = self.parentKey {
 			return KeyedEncodingContainer(
 				InternalTOMLEncoder.KEC<NestedKey>(
 					self.tomlValue.table![parentKey.stringValue]!.table!.tomlValue,
 					parentKey: key,
-					codingPath: self.codingPath,
+					codingPath: self.codingPath + key,
 					userInfo: self.userInfo,
 					dataEncoder: self.dataEncoder
 				)
@@ -198,7 +200,7 @@ extension InternalTOMLEncoder.KEC {
 				InternalTOMLEncoder.KEC<NestedKey>(
 					self.tomlValue,
 					parentKey: key,
-					codingPath: self.codingPath,
+					codingPath: self.codingPath + key,
 					userInfo: self.userInfo,
 					dataEncoder: self.dataEncoder
 				)
@@ -212,7 +214,7 @@ extension InternalTOMLEncoder.KEC {
 			self.tomlValue.table?[parentKey.stringValue]?.table?[key.stringValue] = TOMLArray().tomlValue
 			return InternalTOMLEncoder.UEC(
 				self.tomlValue.table![parentKey.stringValue]!.table![key.stringValue]!.array!,
-				codingPath: self.codingPath,
+				codingPath: self.codingPath + key,
 				userInfo: self.userInfo,
 				dataEncoder: self.dataEncoder
 			)
@@ -220,7 +222,7 @@ extension InternalTOMLEncoder.KEC {
 			self.tomlValue.table?[key.stringValue] = TOMLArray().tomlValue
 			return InternalTOMLEncoder.UEC(
 				self.tomlValue.table![key.stringValue]!.array!,
-				codingPath: self.codingPath,
+				codingPath: self.codingPath + key,
 				userInfo: self.userInfo,
 				dataEncoder: self.dataEncoder
 			)

--- a/Sources/TOMLKit/Encoder/SingleValueEncodingContainer.swift
+++ b/Sources/TOMLKit/Encoder/SingleValueEncodingContainer.swift
@@ -165,7 +165,7 @@ extension InternalTOMLEncoder.SVEC {
 					let encoder = InternalTOMLEncoder(
 						.right((array: array, index: index)),
 						parentKey: self.parentKey,
-						codingPath: self.codingPath,
+						codingPath: self.codingPath + TOMLCodingKey(index: index),
 						userInfo: self.userInfo,
 						dataEncoder: self.dataEncoder
 					)

--- a/Sources/TOMLKit/Encoder/TOMLEncoder.swift
+++ b/Sources/TOMLKit/Encoder/TOMLEncoder.swift
@@ -12,7 +12,7 @@ import struct Foundation.Data
 ///
 ///	You can customize how `Data` is encoded, and how the resulting TOML is formatted.
 ///
-/// To format the TOML document, insert or remove ``FormatOptions`` from `TOMLEncoder`'s `TOMLEncoder/options``.
+/// To format the TOML document, insert or remove ``FormatOptions`` from `TOMLEncoder`'s ``TOMLEncoder/options``.
 ///
 /// To customize the encoding of `Data`, provide a function for ``TOMLEncoder/dataEncoder``:
 ///

--- a/Sources/TOMLKit/Encoder/UnkeyedEncodingContainer.swift
+++ b/Sources/TOMLKit/Encoder/UnkeyedEncodingContainer.swift
@@ -87,7 +87,7 @@ extension InternalTOMLEncoder.UEC {
 				let encoder = InternalTOMLEncoder(
 					.right((array: self.tomlArray, index: self.currentIndex)),
 					parentKey: nil,
-					codingPath: self.codingPath,
+					codingPath: self.codingPath + TOMLCodingKey(index: self.currentIndex),
 					userInfo: self.userInfo,
 					dataEncoder: self.dataEncoder
 				)
@@ -98,14 +98,16 @@ extension InternalTOMLEncoder.UEC {
 		self.currentIndex += 1
 	}
 
-	mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey {
+	mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey>
+		where NestedKey: CodingKey
+	{
 		let table = TOMLTable()
 		self.tomlArray[self.currentIndex] = table
 
 		return KeyedEncodingContainer(
 			InternalTOMLEncoder.KEC<NestedKey>(
 				table.tomlValue,
-				codingPath: self.codingPath,
+				codingPath: self.codingPath + TOMLCodingKey(index: self.currentIndex),
 				userInfo: self.userInfo,
 				dataEncoder: self.dataEncoder
 			)
@@ -116,7 +118,7 @@ extension InternalTOMLEncoder.UEC {
 		self.tomlArray[self.currentIndex] = TOMLArray()
 		return InternalTOMLEncoder.UEC(
 			self.tomlArray[self.currentIndex].array!,
-			codingPath: self.codingPath,
+			codingPath: self.codingPath + TOMLCodingKey(index: self.currentIndex),
 			userInfo: self.userInfo,
 			dataEncoder: self.dataEncoder
 		)

--- a/Sources/TOMLKit/Operators&Extensions.swift
+++ b/Sources/TOMLKit/Operators&Extensions.swift
@@ -10,3 +10,7 @@ extension String {
 		return String(repeating: padding, count: length - self.count) + self
 	}
 }
+
+func + <C: Collection, D>(lhs: C, rhs: D) -> [D] where C.Element == D {
+	lhs + [rhs]
+}

--- a/Sources/TOMLKit/TOML Data Types/TOMLArray/TOMLArray+CollectionConformance.swift
+++ b/Sources/TOMLKit/TOML Data Types/TOMLArray/TOMLArray+CollectionConformance.swift
@@ -58,7 +58,9 @@ extension TOMLArray:
 			self.remove(at: $0) })
 	}
 
-	public func replaceSubrange<C>(_ subrange: Range<Int>, with newElements: C) where C: Collection, TOMLValueConvertible == C.Element {
+	public func replaceSubrange<C>(_ subrange: Range<Int>, with newElements: C) where C: Collection,
+		TOMLValueConvertible == C.Element
+	{
 		self.checkIndex(subrange[subrange.startIndex])
 		self.checkIndex(subrange[subrange.endIndex - 1])
 

--- a/Sources/TOMLKit/TOML Data Types/TOMLValueConvertible.swift
+++ b/Sources/TOMLKit/TOML Data Types/TOMLValueConvertible.swift
@@ -5,13 +5,13 @@
 //  The full text of the license can be found in the file named LICENSE.
 
 #if canImport(Darwin)
-import Darwin.C
+	import Darwin.C
 #elseif canImport(Glibc)
-import Glibc
+	import Glibc
 #elseif canImport(ucrt)
-import ucrt
+	import ucrt
 #else
-#error("Unsupported Platform")
+	#error("Unsupported Platform")
 #endif
 
 import CTOML

--- a/Sources/TOMLKit/TOMLCodingKey.swift
+++ b/Sources/TOMLKit/TOMLCodingKey.swift
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 Jeff Lebrun
+//
+//  Licensed under the MIT License.
+//
+//  The full text of the license can be found in the file named LICENSE.
+
+// Based off of https://github.com/jpsim/Yams/blob/074fd3c61d7f50869d074549369eed3b9436061e/Sources/Yams/Encoder.swift#L243-L263
+struct TOMLCodingKey: CodingKey {
+	var stringValue: String
+	var intValue: Int?
+
+	init?(stringValue: String) {
+		self.stringValue = stringValue
+		self.intValue = nil
+	}
+
+	init?(intValue: Int) {
+		self.stringValue = "\(intValue)"
+		self.intValue = intValue
+	}
+
+	init(index: Int) {
+		self.stringValue = "Index \(index)"
+		self.intValue = index
+	}
+}

--- a/Sources/TOMLKit/TOMLType.swift
+++ b/Sources/TOMLKit/TOMLType.swift
@@ -7,7 +7,7 @@
 import CTOML
 
 /// TOML data types.
-public enum TOMLType: String, CaseIterable {
+public enum TOMLType: String, CaseIterable, CustomStringConvertible {
 	/// A [TOML table](https://toml.io/en/v1.0.0#table).
 	case table
 
@@ -37,6 +37,15 @@ public enum TOMLType: String, CaseIterable {
 
 	init(cTOMLNodeType: CTOMLNodeType) {
 		self = cTOMLNodeType.tomlType
+	}
+
+	public var description: String {
+		switch self {
+			case .int: return "integer"
+			case .double: return "floating-point number"
+			case .dateTime: return "date-time"
+			default: return self.rawValue
+		}
 	}
 }
 


### PR DESCRIPTION
Use `codingPath` in TOMLEncoder and TOMLDecoder to improve thrown `DecodingError`s.
