### PR TITLE
Fix unstable dependency on swift-checkit.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
 		// Use this dependency when one of the `TOMLTable` comparison tests fail and
 		// XCTAssertEqual tells you "<huge TOMLTable> is not equal to <other huge TOMLTable>"
 		// .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.1.0"),
-		.package(name: "Checkit", url: "https://github.com/karwa/swift-checkit.git", .branch("master")),
+		.package(name: "Checkit", url: "https://github.com/karwa/swift-checkit.git", from: "0.0.2"),
 	],
 	targets: [
 		.target(

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -17,7 +17,7 @@ let package = Package(
 		// Use this dependency when one of the `TOMLTable` comparison tests fail and
 		// XCTAssertEqual tells you "<huge TOMLTable> is not equal to <other huge TOMLTable>"
 		// .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.1.0"),
-		.package(name: "Checkit", url: "https://github.com/karwa/swift-checkit.git", .branch("master")),
+		.package(name: "Checkit", url: "https://github.com/karwa/swift-checkit.git", from: "0.0.2"),
 	],
 	targets: [
 		.target(


### PR DESCRIPTION
Hey there!

In your swift package, you have what SwiftPM classifies as an "unstable version" on the `swift-checkit` dependency. SwiftPM is exceptionally strict on versioning requirements of packages that hold dependencies of packages that have "unstable versions".

The main issue with this, is that it disallows any Swift package which includes your dependency from being able to tag a release version on their own packages, with a SwiftPM error in the form of:

```swift
error: Dependencies could not be resolved because root depends on 'consumer-of-tomlkit'
'consumer-of-tomlkit' cannot be used because package 'consumer-of-tomlkit' is required using a stable-version but 'consumer-of-tomlkit' depends on an unstable-version package 'tomlkit'
```

I have provided the simple fix to tag the `0.0.2` release of `swift-checkit`, which is even with the `master` branch of `swift-checkit` at the time of writing.

Thank you!