### PR TITLE
Fix decoding bugs

### DIFF
--- a/Sources/TOMLKit/Decoder/UnkeyedDecodingContainer.swift
+++ b/Sources/TOMLKit/Decoder/UnkeyedDecodingContainer.swift
@@ -168,9 +168,9 @@ extension InternalTOMLDecoder.UDC {
 				strictDecoding: self.strictDecoding,
 				notDecodedKeys: self.notDecodedKeys
 			)
-            let decodable = try T(from: decoder)
-            self.currentIndex += 1
-            return decodable
+			let decodable = try T(from: decoder)
+			self.currentIndex += 1
+			return decodable
 		}
 	}
 
@@ -198,8 +198,8 @@ extension InternalTOMLDecoder.UDC {
 				notDecodedKeys: self.notDecodedKeys
 			)
 		)
-        self.currentIndex += 1
-        return container
+		self.currentIndex += 1
+		return container
 	}
 
 	func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
@@ -222,8 +222,8 @@ extension InternalTOMLDecoder.UDC {
 			strictDecoding: self.strictDecoding,
 			notDecodedKeys: self.notDecodedKeys
 		)
-        self.currentIndex += 1
-        return container
+		self.currentIndex += 1
+		return container
 	}
 
 	func superDecoder() throws -> Decoder {

--- a/Sources/TOMLKit/Decoder/UnkeyedDecodingContainer.swift
+++ b/Sources/TOMLKit/Decoder/UnkeyedDecodingContainer.swift
@@ -168,8 +168,9 @@ extension InternalTOMLDecoder.UDC {
 				strictDecoding: self.strictDecoding,
 				notDecodedKeys: self.notDecodedKeys
 			)
-			self.currentIndex += 1
-			return try T(from: decoder)
+            let decodable = try T(from: decoder)
+            self.currentIndex += 1
+            return decodable
 		}
 	}
 

--- a/Sources/TOMLKit/Decoder/UnkeyedDecodingContainer.swift
+++ b/Sources/TOMLKit/Decoder/UnkeyedDecodingContainer.swift
@@ -188,7 +188,7 @@ extension InternalTOMLDecoder.UDC {
 			)
 		}
 
-		return KeyedDecodingContainer<NestedKey>(
+		let container = KeyedDecodingContainer<NestedKey>(
 			InternalTOMLDecoder.KDC(
 				table: table,
 				codingPath: self.codingPath + TOMLCodingKey(index: self.currentIndex),
@@ -198,6 +198,8 @@ extension InternalTOMLDecoder.UDC {
 				notDecodedKeys: self.notDecodedKeys
 			)
 		)
+        self.currentIndex += 1
+        return container
 	}
 
 	func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
@@ -212,7 +214,7 @@ extension InternalTOMLDecoder.UDC {
 			)
 		}
 
-		return InternalTOMLDecoder.UDC(
+		let container = InternalTOMLDecoder.UDC(
 			nestedArray,
 			codingPath: self.codingPath + TOMLCodingKey(index: self.currentIndex),
 			userInfo: self.userInfo,
@@ -220,6 +222,8 @@ extension InternalTOMLDecoder.UDC {
 			strictDecoding: self.strictDecoding,
 			notDecodedKeys: self.notDecodedKeys
 		)
+        self.currentIndex += 1
+        return container
 	}
 
 	func superDecoder() throws -> Decoder {

--- a/Tests/TOMLKitTests/TOMLKitTests.swift
+++ b/Tests/TOMLKitTests/TOMLKitTests.swift
@@ -447,4 +447,18 @@ final class TOMLKitTests: XCTestCase {
 			XCTFail("DecodingError did not occur.")
 		}
 	}
+    
+    func testFailingToDecodingDateFromUDC() throws {
+        let udc = InternalTOMLDecoder.UDC(
+            ["Not a date"],
+            codingPath: [],
+            userInfo: [:],
+            dataDecoder: { $0.string != nil ? Data(base64Encoded: $0.string!) : nil },
+            strictDecoding: false,
+            notDecodedKeys: InternalTOMLDecoder.NotDecodedKeys()
+        )
+        
+        XCTAssertThrowsError(try udc.decode(Date.self))
+        XCTAssertEqual(udc.currentIndex, 0)
+    }
 }

--- a/Tests/TOMLKitTests/TOMLKitTests.swift
+++ b/Tests/TOMLKitTests/TOMLKitTests.swift
@@ -447,58 +447,58 @@ final class TOMLKitTests: XCTestCase {
 			XCTFail("DecodingError did not occur.")
 		}
 	}
-    
-    func testFailingToDecodingDateFromUDCShouldNotIncreaseIndex() throws {
-        let udc = InternalTOMLDecoder.UDC(
-            ["Not a date"],
-            codingPath: [],
-            userInfo: [:],
-            dataDecoder: { $0.string != nil ? Data(base64Encoded: $0.string!) : nil },
-            strictDecoding: false,
-            notDecodedKeys: InternalTOMLDecoder.NotDecodedKeys()
-        )
-        
-        XCTAssertThrowsError(try udc.decode(Date.self))
-        XCTAssertEqual(udc.currentIndex, 0)
-    }
-    
-    func testDecodingObjectFromUDCShouldIncreaseIndex() throws {
-        struct StringCodingKey: CodingKey, Equatable {
-            var stringValue: String
-            
-            init(stringValue: String) {
-                self.stringValue = stringValue
-            }
-            
-            var intValue: Int? { nil }
-            init?(intValue: Int) { nil }
-        }
-
-        
-        let udc = InternalTOMLDecoder.UDC(
-            [TOMLTable(["key": "value"], inline: false)],
-            codingPath: [],
-            userInfo: [:],
-            dataDecoder: { $0.string != nil ? Data(base64Encoded: $0.string!) : nil },
-            strictDecoding: false,
-            notDecodedKeys: InternalTOMLDecoder.NotDecodedKeys()
-        )
-        
-        let _ = try udc.nestedContainer(keyedBy: StringCodingKey.self)
-        XCTAssertEqual(udc.currentIndex, 1)
-    }
-    
-    func testDecodingArrayFromUDCShouldIncreaseIndex() throws {
-        let udc = InternalTOMLDecoder.UDC(
-            [["value"]],
-            codingPath: [],
-            userInfo: [:],
-            dataDecoder: { $0.string != nil ? Data(base64Encoded: $0.string!) : nil },
-            strictDecoding: false,
-            notDecodedKeys: InternalTOMLDecoder.NotDecodedKeys()
-        )
-        
-        let _ = try udc.nestedUnkeyedContainer()
-        XCTAssertEqual(udc.currentIndex, 1)
-    }
+	
+	func testFailingToDecodingDateFromUDCShouldNotIncreaseIndex() throws {
+		let udc = InternalTOMLDecoder.UDC(
+			["Not a date"],
+			codingPath: [],
+			userInfo: [:],
+			dataDecoder: { $0.string != nil ? Data(base64Encoded: $0.string!) : nil },
+			strictDecoding: false,
+			notDecodedKeys: InternalTOMLDecoder.NotDecodedKeys()
+		)
+		
+		XCTAssertThrowsError(try udc.decode(Date.self))
+		XCTAssertEqual(udc.currentIndex, 0)
+	}
+	
+	func testDecodingObjectFromUDCShouldIncreaseIndex() throws {
+		struct StringCodingKey: CodingKey, Equatable {
+			var stringValue: String
+			
+			init(stringValue: String) {
+				self.stringValue = stringValue
+			}
+			
+			var intValue: Int? { nil }
+			init?(intValue: Int) { nil }
+		}
+		
+		
+		let udc = InternalTOMLDecoder.UDC(
+			[TOMLTable(["key": "value"], inline: false)],
+			codingPath: [],
+			userInfo: [:],
+			dataDecoder: { $0.string != nil ? Data(base64Encoded: $0.string!) : nil },
+			strictDecoding: false,
+			notDecodedKeys: InternalTOMLDecoder.NotDecodedKeys()
+		)
+		
+		let _ = try udc.nestedContainer(keyedBy: StringCodingKey.self)
+		XCTAssertEqual(udc.currentIndex, 1)
+	}
+	
+	func testDecodingArrayFromUDCShouldIncreaseIndex() throws {
+		let udc = InternalTOMLDecoder.UDC(
+			[["value"]],
+			codingPath: [],
+			userInfo: [:],
+			dataDecoder: { $0.string != nil ? Data(base64Encoded: $0.string!) : nil },
+			strictDecoding: false,
+			notDecodedKeys: InternalTOMLDecoder.NotDecodedKeys()
+		)
+		
+		let _ = try udc.nestedUnkeyedContainer()
+		XCTAssertEqual(udc.currentIndex, 1)
+	}
 }

--- a/Tests/TOMLKitTests/TOMLKitTests.swift
+++ b/Tests/TOMLKitTests/TOMLKitTests.swift
@@ -448,7 +448,7 @@ final class TOMLKitTests: XCTestCase {
 		}
 	}
     
-    func testFailingToDecodingDateFromUDC() throws {
+    func testFailingToDecodingDateFromUDCShouldNotIncreaseIndex() throws {
         let udc = InternalTOMLDecoder.UDC(
             ["Not a date"],
             codingPath: [],
@@ -462,7 +462,7 @@ final class TOMLKitTests: XCTestCase {
         XCTAssertEqual(udc.currentIndex, 0)
     }
     
-    func testDecodingObjectFromArray() throws {
+    func testDecodingObjectFromUDCShouldIncreaseIndex() throws {
         struct StringCodingKey: CodingKey, Equatable {
             var stringValue: String
             
@@ -488,7 +488,7 @@ final class TOMLKitTests: XCTestCase {
         XCTAssertEqual(udc.currentIndex, 1)
     }
     
-    func testDecodingArrayFromArray() throws {
+    func testDecodingArrayFromUDCShouldIncreaseIndex() throws {
         let udc = InternalTOMLDecoder.UDC(
             [["value"]],
             codingPath: [],

--- a/Tests/TOMLKitTests/TOMLKitTests.swift
+++ b/Tests/TOMLKitTests/TOMLKitTests.swift
@@ -461,4 +461,44 @@ final class TOMLKitTests: XCTestCase {
         XCTAssertThrowsError(try udc.decode(Date.self))
         XCTAssertEqual(udc.currentIndex, 0)
     }
+    
+    func testDecodingObjectFromArray() throws {
+        struct StringCodingKey: CodingKey, Equatable {
+            var stringValue: String
+            
+            init(stringValue: String) {
+                self.stringValue = stringValue
+            }
+            
+            var intValue: Int? { nil }
+            init?(intValue: Int) { nil }
+        }
+
+        
+        let udc = InternalTOMLDecoder.UDC(
+            [TOMLTable(["key": "value"], inline: false)],
+            codingPath: [],
+            userInfo: [:],
+            dataDecoder: { $0.string != nil ? Data(base64Encoded: $0.string!) : nil },
+            strictDecoding: false,
+            notDecodedKeys: InternalTOMLDecoder.NotDecodedKeys()
+        )
+        
+        let _ = try udc.nestedContainer(keyedBy: StringCodingKey.self)
+        XCTAssertEqual(udc.currentIndex, 1)
+    }
+    
+    func testDecodingArrayFromArray() throws {
+        let udc = InternalTOMLDecoder.UDC(
+            [["value"]],
+            codingPath: [],
+            userInfo: [:],
+            dataDecoder: { $0.string != nil ? Data(base64Encoded: $0.string!) : nil },
+            strictDecoding: false,
+            notDecodedKeys: InternalTOMLDecoder.NotDecodedKeys()
+        )
+        
+        let _ = try udc.nestedUnkeyedContainer()
+        XCTAssertEqual(udc.currentIndex, 1)
+    }
 }


### PR DESCRIPTION
Hey!

Not sure if I should open an issue first, but I found some bugs in `InternalTOMLDecoder.UDC` that can cause decoding issues in my use cases. Sometimes skipping values, other times getting stuck in infinite loops. I've added tests and fixes for these cases. Let me know if you want me to adjust the code at all.