### PR TITLE
Fix `strictDecoding` by only propagating not-decoded keys when decoding is successful

### DIFF
--- a/Sources/TOMLKit/Decoder/KeyedDecodingContainerProtocol.swift
+++ b/Sources/TOMLKit/Decoder/KeyedDecodingContainerProtocol.swift
@@ -228,13 +228,24 @@ extension InternalTOMLDecoder.KDC {
 						codingPath: self.codingPath + key,
 						dataDecoder: self.dataDecoder,
 						strictDecoding: self.strictDecoding,
-						notDecodedKeys: self.notDecodedKeys
+						notDecodedKeys: InternalTOMLDecoder.NotDecodedKeys()
 					)
 
 					self.decodedKeys.append(key.stringValue)
 
-					return try T(from: decoder)
+					let decodedValue = try T(from: decoder)
+
+					// Only propagate not-decoded keys if the decoding was successful.
+					// Otherwise `Decodable` implementations that attempt multiple
+					// decoding strategies in succession (trying the next if the
+					// previous one failed), don't work.
+					for (key, path) in decoder.notDecodedKeys.keys {
+						self.notDecodedKeys.keys[key] = path
+					}
+
+					return decodedValue
 				}
+
 		}
 	}
 

--- a/Sources/TOMLKit/Decoder/UnkeyedDecodingContainer.swift
+++ b/Sources/TOMLKit/Decoder/UnkeyedDecodingContainer.swift
@@ -166,11 +166,21 @@ extension InternalTOMLDecoder.UDC {
 				codingPath: self.codingPath + TOMLCodingKey(index: self.currentIndex),
 				dataDecoder: self.dataDecoder,
 				strictDecoding: self.strictDecoding,
-				notDecodedKeys: self.notDecodedKeys
+				notDecodedKeys: InternalTOMLDecoder.NotDecodedKeys()
 			)
-			let decodable = try T(from: decoder)
+
+			let decodedValue = try T(from: decoder)
 			self.currentIndex += 1
-			return decodable
+
+			// Only propagate not-decoded keys if the decoding was successful.
+			// Otherwise `Decodable` implementations that attempt multiple
+			// decoding strategies in succession (trying the next if the
+			// previous one failed), don't work.
+			for (key, path) in decoder.notDecodedKeys.keys {
+				self.notDecodedKeys.keys[key] = path
+			}
+
+			return decodedValue
 		}
 	}
 

--- a/Tests/TOMLKitTests/TOMLKitTests.swift
+++ b/Tests/TOMLKitTests/TOMLKitTests.swift
@@ -19,15 +19,6 @@ enum CodableEnum: String, Codable, Equatable {
 	case abc
 	case def
 	case ghi
-
-	public static func == (lhs: Self, rhs: Self) -> Bool {
-		switch (lhs, rhs) {
-			case (.abc, .abc): return true
-			case (.def, .def): return true
-			case (.ghi, .ghi): return true
-			default: return false
-		}
-	}
 }
 
 struct CodableStruct: Codable, Equatable {
@@ -500,5 +491,45 @@ final class TOMLKitTests: XCTestCase {
 		
 		let _ = try udc.nestedUnkeyedContainer()
 		XCTAssertEqual(udc.currentIndex, 1)
+	}
+
+	// Tests for a bug where not-decoded keys would carry over from unsuccessful
+	// decoding attempts, breaking the common 'try one thing then retry another'
+	// decoding pattern. This bug was specific to decoders with
+	// `strictDecoding: true`.
+	func testRetry() throws {
+		struct SimpleCodableStruct: Codable, Equatable {
+			var value: Int
+		}
+
+		enum SimpleOrComplex: Decodable, Equatable {
+			case simple(SimpleCodableStruct)
+			case complex(CodableStruct)
+
+			init(from decoder: Decoder) throws {
+				if let container = try? decoder.singleValueContainer() {
+					if let value = try? container.decode(CodableStruct.self) {
+						self = .complex(value)
+						return
+					} else if let value = try? container.decode(SimpleCodableStruct.self) {
+						self = .simple(value)
+						return
+					}
+				}
+				throw DecodingError.dataCorrupted(.init(
+					codingPath: [],
+					debugDescription: "Expected CodableStruct or SimpleCodableStruct"
+				))
+			}
+		}
+		
+		let toml = "value = 2"
+
+		// Before the bug got fixed, this line would throw an unused key error.
+		let value = try TOMLDecoder(strictDecoding: true).decode(SimpleOrComplex.self, from: toml)
+
+		// We don't actually expect this to fail, it's not the point of the test, but
+		// might as well assert it just in case.
+		XCTAssertEqual(value, .simple(SimpleCodableStruct(value: 2)))
 	}
 }


### PR DESCRIPTION
I encountered a `strictDecoding`-related `TOMLDecoder` bug while working on Swift Bundler. If a custom `Decodable` implementation (`init(from:)`) attempts to decode with an initial strategy and then attempts a different strategy on failure, any keys not used by the initial failed (and ignored) attempt still get propagated in `notDecodedKeys` and end up causing decoding to throw an unused key error right at the end of the decoding process.

There were two flavours of this issue;

1. If a custom `Decodable` implementation somewhere in the decoding process throws an error, then its unused keys still get propagated.
2. If you create a container (e.g. a keyed container) and then realise that the value isn't in the format you expect and then create a single value container to try a different approach, the first container's unused keys still get propagated even though there wasn't any distinct point of failure in the container's eyes.

Flavour 1 was relatively easy to fix. I just updated the `decode<T>(_:)` method of each container type to give the inner decoder a fresh `NotDecodedKeys` instance and then merge the keys, but only if decoding was successful.

Flavour 2 is clearly harder to address. In my current patch I've made the assumption that whenever a container gets created from an `InternalTOMLDecoder`, any containers created from the decoder in the past have now been superseded. I feel like there could be some strange situation where someone might create two containers and make use of both of them to construct the final output, but I dunno if that needs to be supported, and it definitely wouldn't be as common as the 'try one thing and then try another' pattern that I was using when I discovered this issue. Let me know what you think

I've added tests for both flavours.